### PR TITLE
Fixed licensing issue and added licensing boilerplate

### DIFF
--- a/pyrdp/layer/rdp/security.py
+++ b/pyrdp/layer/rdp/security.py
@@ -135,7 +135,9 @@ class TLSSecurityLayer(SecurityLayer):
         self.securityHeaderExpected = False
 
     def recv(self, data: bytes):
-        if not self.securityHeaderExpected:
+        # Licensing happens in the security layer
+        licensingBytes = b"\x80\x00"
+        if not self.securityHeaderExpected and data[0:2] != b"\x80\x00":
             if self.next is not None:
                 self.next.recv(data)
         else:

--- a/pyrdp/layer/rdp/security.py
+++ b/pyrdp/layer/rdp/security.py
@@ -137,7 +137,7 @@ class TLSSecurityLayer(SecurityLayer):
     def recv(self, data: bytes):
         # Licensing happens in the security layer
         licensingBytes = b"\x80\x00"
-        if not self.securityHeaderExpected and data[0:2] != b"\x80\x00":
+        if not self.securityHeaderExpected and data[0:2] != licensingBytes:
             if self.next is not None:
                 self.next.recv(data)
         else:

--- a/pyrdp/parser/rdp/licensing.py
+++ b/pyrdp/parser/rdp/licensing.py
@@ -20,7 +20,15 @@ class LicensingParser(Parser):
 
     def __init__(self):
         super().__init__()
+
         self.parsers = {
+            LicensingPDUType.LICENSE_REQUEST: self.parseLicenseRequest,
+            LicensingPDUType.PLATFORM_CHALLENGE: self.parsePlatformChallenge,
+            LicensingPDUType.NEW_LICENSE: self.parseNewLicense,
+            LicensingPDUType.UPGRADE_LICENSE: self.parseUpgradeLicense,
+            LicensingPDUType.LICENSE_INFO: self.parseLicenseInfo,
+            LicensingPDUType.NEW_LICENSE_REQUEST: self.parseNewLicenseRequest,
+            LicensingPDUType.PLATFORM_CHALLENGE_RESPONSE: self.parsePlatformChallengeResponse,
             LicensingPDUType.ERROR_ALERT: self.parseErrorAlert,
         }
 
@@ -51,6 +59,34 @@ class LicensingParser(Parser):
         length = Uint16LE.unpack(stream)
         data = stream.read(length)
         return LicenseBinaryBlob(type, data)
+
+    def parseLicenseRequest(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/a870d76a-639b-4757-9370-a9bdfbfd6961
+        raise ("parseLicenseRequest isn't implemented yet")
+
+    def parsePlatformChallenge(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/3e78e067-83a8-42b5-b5b3-054679ade7c7
+        raise ("parsePlatformChallenge isn't implemented yet")
+
+    def parseNewLicense(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/73c596f1-9550-4649-b880-2947c36c1bb6
+        raise ("parseNewLicense isn't implemented yet")
+
+    def parseUpgradeLicense(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/94f9f260-fe9d-4429-b3b5-228bef28bc5d
+        raise ("parseUpgradeLicense isn't implemented yet")
+
+    def parseLicenseInfo(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/9fea482b-f9e5-4175-9350-ac540a804eba
+        raise ("parseLicenseInfo isn't implemented yet")
+
+    def parseNewLicenseRequest(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/9b4e7ee7-9e85-46f0-9583-77cfd397864e
+        raise ("parseNewLicenseRequest isn't implemented yet")
+
+    def parsePlatformChallengeResponse(self, stream, flags):
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/58e79794-58f8-4607-a510-c0b5fef49c40
+        raise ("parsePlatformChallengeResponse isn't implemented yet")
 
     def parseErrorAlert(self, stream, flags):
         """


### PR DESCRIPTION
I have fixed the issue discussed in #104. The actual fix in in SecurityMITM.py, but I have left some boilerplate code inside the (unused) licensing.py if we ever feel like parsing the data.

I had to make a pre-parse validation in order to avoir sending licensing data to the slowpath. I am not quite happy with that method, and I'm open to change it if you have any propositions.