### PR TITLE
Pyrdp-player improvements

### DIFF
--- a/pyrdp/player/BaseWindow.py
+++ b/pyrdp/player/BaseWindow.py
@@ -28,7 +28,7 @@ class BaseWindow(QTabWidget):
         self.options = options
         self.closeTabShortcut = QShortcut(QKeySequence("Ctrl+W"), self, self.onCtrlW)
 
-    def onTabClosed(self, index: int) -> None:
+    def onTabClosed(self, index: int):
         """
         Gracefully closes the tab by calling the onClose method
         :param index: Index of the closed tab
@@ -38,13 +38,13 @@ class BaseWindow(QTabWidget):
         self.removeTab(index)
 
 
-    def onTabCloseRequest(self, index: int) -> None:
+    def onTabCloseRequest(self, index: int):
         """
         By default, will close the tab. Can be overriden to add validation.
         """
 
         self.onTabClosed(index)
 
-    def onCtrlW(self) -> None:
+    def onCtrlW(self):
         if self.options.get("closeTabOnCtrlW") and self.count() > 0:
             self.onTabCloseRequest(self.currentIndex())

--- a/pyrdp/player/BaseWindow.py
+++ b/pyrdp/player/BaseWindow.py
@@ -28,7 +28,7 @@ class BaseWindow(QTabWidget):
         self.options = options
         self.closeTabShortcut = QShortcut(QKeySequence("Ctrl+W"), self, self.onCtrlW)
 
-    def onTabClosed(self, index):
+    def onTabClosed(self, index: int) -> None:
         """
         Gracefully closes the tab by calling the onClose method
         :param index: Index of the closed tab
@@ -38,13 +38,13 @@ class BaseWindow(QTabWidget):
         self.removeTab(index)
 
 
-    def onTabCloseRequest(self, index):
+    def onTabCloseRequest(self, index: int) -> None:
         """
         By default, will close the tab. Can be overriden to add validation.
         """
 
         self.onTabClosed(index)
 
-    def onCtrlW(self):
+    def onCtrlW(self) -> None:
         if self.options.get("closeTabOnCtrlW") and self.count() > 0:
             self.onTabCloseRequest(self.currentIndex())

--- a/pyrdp/player/BaseWindow.py
+++ b/pyrdp/player/BaseWindow.py
@@ -5,8 +5,10 @@
 #
 
 import logging
+from typing import Dict
 
-from PySide2.QtWidgets import QTabWidget, QWidget
+from PySide2.QtGui import QKeySequence
+from PySide2.QtWidgets import QShortcut, QTabWidget, QWidget
 
 from pyrdp.logging import LOGGER_NAMES
 
@@ -17,12 +19,14 @@ class BaseWindow(QTabWidget):
     regardless of their origin (network or file).
     """
 
-    def __init__(self, parent: QWidget = None, maxTabCount = 250):
+    def __init__(self, options: Dict[str, object], parent: QWidget = None, maxTabCount = 250):
         super().__init__(parent)
         self.maxTabCount = maxTabCount
         self.setTabsClosable(True)
-        self.tabCloseRequested.connect(self.onTabClosed)
+        self.tabCloseRequested.connect(self.onTabCloseRequest)
         self.log = logging.getLogger(LOGGER_NAMES.PLAYER)
+        self.options = options
+        self.closeTabShortcut = QShortcut(QKeySequence("Ctrl+W"), self, self.onCtrlW)
 
     def onTabClosed(self, index):
         """
@@ -32,3 +36,15 @@ class BaseWindow(QTabWidget):
         tab = self.widget(index)
         tab.onClose()
         self.removeTab(index)
+
+
+    def onTabCloseRequest(self, index):
+        """
+        By default, will close the tab. Can be overriden to add validation.
+        """
+
+        self.onTabClosed(index)
+
+    def onCtrlW(self):
+        if self.options.get("closeTabOnCtrlW") and self.count() > 0:
+            self.onTabCloseRequest(self.currentIndex())

--- a/pyrdp/player/LiveTab.py
+++ b/pyrdp/player/LiveTab.py
@@ -23,7 +23,7 @@ class LiveTab(BaseTab, DirectoryObserver):
     Tab playing a live RDP connection as data is being received over the network.
     """
 
-    connectionClosed = Signal(object)
+    connectionRenameTab = Signal(object, str, bool)
 
     def __init__(self, parent: QWidget = None):
         layers = AsyncIOPlayerLayerSet()
@@ -33,7 +33,7 @@ class LiveTab(BaseTab, DirectoryObserver):
         self.layers = layers
         self.rdpWidget = rdpWidget
         self.fileSystem = FileSystem()
-        self.eventHandler = LiveEventHandler(self.widget, self.text, self.log, self.fileSystem, self.layers.player)
+        self.eventHandler = LiveEventHandler(self.widget, self.text, self.log, self.fileSystem, self.layers.player, self.connectionRenameTab, self)
         self.attackerBar = AttackerBar()
 
         self.attackerBar.controlTaken.connect(lambda: self.rdpWidget.setControlState(True))
@@ -55,9 +55,6 @@ class LiveTab(BaseTab, DirectoryObserver):
 
     def getProtocol(self) -> asyncio.Protocol:
         return self.layers.tcp
-
-    def onDisconnection(self):
-        self.connectionClosed.emit()
 
     def onClose(self):
         self.layers.tcp.disconnect(True)

--- a/pyrdp/player/LiveTab.py
+++ b/pyrdp/player/LiveTab.py
@@ -6,7 +6,7 @@
 
 import asyncio
 
-from PySide2.QtCore import Qt, Signal
+from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QHBoxLayout, QWidget
 
 from pyrdp.player.AttackerBar import AttackerBar
@@ -23,8 +23,6 @@ class LiveTab(BaseTab, DirectoryObserver):
     Tab playing a live RDP connection as data is being received over the network.
     """
 
-    connectionRenameTab = Signal(object, str, bool)
-
     def __init__(self, parent: QWidget = None):
         layers = AsyncIOPlayerLayerSet()
         rdpWidget = RDPMITMWidget(1024, 768, layers.player)
@@ -33,8 +31,10 @@ class LiveTab(BaseTab, DirectoryObserver):
         self.layers = layers
         self.rdpWidget = rdpWidget
         self.fileSystem = FileSystem()
-        self.eventHandler = LiveEventHandler(self.widget, self.text, self.log, self.fileSystem, self.layers.player, self.connectionRenameTab, self)
+        self.eventHandler = LiveEventHandler(self.widget, self.text, self.log, self.fileSystem, self.layers.player, self)
         self.attackerBar = AttackerBar()
+        self.connectionClosed = self.eventHandler.connectionClosed
+        self.renameTab = self.eventHandler.renameTab
 
         self.attackerBar.controlTaken.connect(lambda: self.rdpWidget.setControlState(True))
         self.attackerBar.controlReleased.connect(lambda: self.rdpWidget.setControlState(False))

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -40,7 +40,7 @@ class LiveWindow(BaseWindow):
         tab = self.queue.get()
         return tab.getProtocol()
 
-    def createLivePlayerTab(self) -> None:
+    def createLivePlayerTab(self):
         tab = LiveTab()
         tab.connectionRenameTab.connect(self.renameLivePlayerTab)
         self.addTab(tab, "New connection")
@@ -51,7 +51,7 @@ class LiveWindow(BaseWindow):
         self.updateCountSignal.emit()
         self.queue.put(tab)
 
-    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool) -> None:
+    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool):
         index = self.indexOf(tab)
         if closed:
             text = self.tabText(index)
@@ -59,22 +59,22 @@ class LiveWindow(BaseWindow):
         elif name:
             self.setTabText(index, name)
 
-    def onClose(self) -> None:
+    def onClose(self):
         self.server.stop()
 
-    def sendKeySequence(self, keys: [Qt.Key]) -> None:
+    def sendKeySequence(self, keys: [Qt.Key]):
         tab: LiveTab = self.currentWidget()
 
         if tab is not None:
             tab.sendKeySequence(keys)
 
-    def sendText(self, text: str) -> None:
+    def sendText(self, text: str):
         tab: LiveTab = self.currentWidget()
 
         if tab is not None:
             tab.sendText(text)
 
-    def onTabClosed(self, index: int) -> None:
+    def onTabClosed(self, index: int):
         """
         Gracefully closes the tab by calling the onClose method
         :param index: Index of the closed tab
@@ -82,7 +82,7 @@ class LiveWindow(BaseWindow):
         super().onTabClosed(index)
         self.updateCountSignal.emit()
 
-    def onTabCloseRequest(self, index: int) -> None:
+    def onTabCloseRequest(self, index: int):
         """
         Prompt the user for validation when the connection is live, then forward call to the parent.
         """

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -6,9 +6,10 @@
 
 import asyncio
 from queue import Queue
+from typing import Dict
 
-from PySide2.QtCore import Signal, Qt
-from PySide2.QtWidgets import QApplication, QWidget
+from PySide2.QtCore import Qt, Signal
+from PySide2.QtWidgets import QApplication, QMessageBox, QWidget
 
 from pyrdp.player.BaseWindow import BaseWindow
 from pyrdp.player.LiveTab import LiveTab
@@ -19,16 +20,20 @@ class LiveWindow(BaseWindow):
     """
     Class that holds logic for live player (network RDP connections as they happen) tabs.
     """
-    connectionReceived = Signal()
 
-    def __init__(self, address: str, port: int, parent: QWidget = None):
-        super().__init__(parent)
+    connectionReceived = Signal()
+    closedTabText = " - Closed"
+
+    def __init__(self, address: str, port: int, updateCountSignal: Signal, options: Dict[str, object], parent: QWidget = None):
+        super().__init__(options, parent)
+
         QApplication.instance().aboutToQuit.connect(self.onClose)
 
         self.server = LiveThread(address, port, self.onConnection)
         self.server.start()
         self.connectionReceived.connect(self.createLivePlayerTab)
         self.queue = Queue()
+        self.updateCountSignal = updateCountSignal
 
     def onConnection(self) -> asyncio.Protocol:
         self.connectionReceived.emit()
@@ -39,14 +44,18 @@ class LiveWindow(BaseWindow):
         tab = LiveTab()
         tab.connectionRenameTab.connect(self.renameLivePlayerTab)
         self.addTab(tab, "New connection")
-        self.setCurrentIndex(self.count() - 1)
+
+        if self.options.get("focusNewTab"):
+            self.setCurrentIndex(self.count() - 1)
+
+        self.updateCountSignal.emit()
         self.queue.put(tab)
 
     def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool):
         index = self.indexOf(tab)
         if closed:
             text = self.tabText(index)
-            self.setTabText(index, text + " - Closed")
+            self.setTabText(index, text + self.closedTabText)
         elif name:
             self.setTabText(index, name)
 
@@ -64,3 +73,24 @@ class LiveWindow(BaseWindow):
 
         if tab is not None:
             tab.sendText(text)
+
+    def onTabClosed(self, index):
+        """
+        Gracefully closes the tab by calling the onClose method
+        :param index: Index of the closed tab
+        """
+        super().onTabClosed(index)
+        self.updateCountSignal.emit()
+
+    def onTabCloseRequest(self, index):
+        """
+        Prompt the user for validation when the connection is live, then forward call to the parent.
+        """
+        text = self.tabText(index)
+
+        if not text.endswith(self.closedTabText):
+            reply = QMessageBox.question(self, "Confirm close", "Are you sure you want to close a tab with an active connection?", QMessageBox.Yes|QMessageBox.No)
+            if reply == QMessageBox.No:
+                return
+
+        super().onTabCloseRequest(index)

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -37,15 +37,18 @@ class LiveWindow(BaseWindow):
 
     def createLivePlayerTab(self):
         tab = LiveTab()
-        tab.connectionClosed.connect(self.onConnectionClosed)
+        tab.connectionRenameTab.connect(self.renameLivePlayerTab)
         self.addTab(tab, "New connection")
         self.setCurrentIndex(self.count() - 1)
         self.queue.put(tab)
 
-    def onConnectionClosed(self, tab: LiveTab):
+    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool):
         index = self.indexOf(tab)
-        text = self.tabText(index)
-        self.setTabText(index, text + " - Closed")
+        if closed:
+            text = self.tabText(index)
+            self.setTabText(index, text + " - Closed")
+        elif name:
+            self.setTabText(index, name)
 
     def onClose(self):
         self.server.stop()

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -40,7 +40,7 @@ class LiveWindow(BaseWindow):
         tab = self.queue.get()
         return tab.getProtocol()
 
-    def createLivePlayerTab(self):
+    def createLivePlayerTab(self) -> None:
         tab = LiveTab()
         tab.connectionRenameTab.connect(self.renameLivePlayerTab)
         self.addTab(tab, "New connection")
@@ -51,7 +51,7 @@ class LiveWindow(BaseWindow):
         self.updateCountSignal.emit()
         self.queue.put(tab)
 
-    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool):
+    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool) -> None:
         index = self.indexOf(tab)
         if closed:
             text = self.tabText(index)
@@ -59,22 +59,22 @@ class LiveWindow(BaseWindow):
         elif name:
             self.setTabText(index, name)
 
-    def onClose(self):
+    def onClose(self) -> None:
         self.server.stop()
 
-    def sendKeySequence(self, keys: [Qt.Key]):
+    def sendKeySequence(self, keys: [Qt.Key]) -> None:
         tab: LiveTab = self.currentWidget()
 
         if tab is not None:
             tab.sendKeySequence(keys)
 
-    def sendText(self, text: str):
+    def sendText(self, text: str) -> None:
         tab: LiveTab = self.currentWidget()
 
         if tab is not None:
             tab.sendText(text)
 
-    def onTabClosed(self, index):
+    def onTabClosed(self, index: int) -> None:
         """
         Gracefully closes the tab by calling the onClose method
         :param index: Index of the closed tab
@@ -82,7 +82,7 @@ class LiveWindow(BaseWindow):
         super().onTabClosed(index)
         self.updateCountSignal.emit()
 
-    def onTabCloseRequest(self, index):
+    def onTabCloseRequest(self, index: int) -> None:
         """
         Prompt the user for validation when the connection is live, then forward call to the parent.
         """

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -42,7 +42,8 @@ class LiveWindow(BaseWindow):
 
     def createLivePlayerTab(self):
         tab = LiveTab()
-        tab.connectionRenameTab.connect(self.renameLivePlayerTab)
+        tab.renameTab.connect(self.renameLivePlayerTab)
+        tab.connectionClosed.connect(self.onConnectionClosed)
         self.addTab(tab, "New connection")
 
         if self.options.get("focusNewTab"):
@@ -51,16 +52,18 @@ class LiveWindow(BaseWindow):
         self.updateCountSignal.emit()
         self.queue.put(tab)
 
-    def renameLivePlayerTab(self, tab: LiveTab, name: str, closed: bool):
+    def renameLivePlayerTab(self, tab: LiveTab, name: str):
         index = self.indexOf(tab)
-        if closed:
-            text = self.tabText(index)
-            self.setTabText(index, text + self.closedTabText)
-        elif name:
-            self.setTabText(index, name)
+        self.setTabText(index, name)
 
     def onClose(self):
         self.server.stop()
+
+    def onConnectionClosed(self, tab: LiveTab):
+        index = self.indexOf(tab)
+        text = self.tabText(index)
+        name = text + self.closedTabText
+        self.setTabText(index, name)
 
     def sendKeySequence(self, keys: [Qt.Key]):
         tab: LiveTab = self.currentWidget()

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -76,7 +76,7 @@ class MainWindow(QMainWindow):
         closeTabOnCtrlW = QAction("Close current tab on Ctrl+W", self)
         closeTabOnCtrlW.setCheckable(True)
         closeTabOnCtrlW.setChecked(self.options.get("closeTabOnCtrlW"))
-        closeTabOnCtrlW.triggered.connect(lambda: self.togglecloseTabOnCtrlW())
+        closeTabOnCtrlW.triggered.connect(lambda: self.toggleCloseTabOnCtrlW())
 
         # Create menu
         menuBar = self.menuBar()
@@ -97,18 +97,18 @@ class MainWindow(QMainWindow):
         for fileName in filesToRead:
             self.replayWindow.openFile(fileName)
 
-    def onOpenFile(self):
+    def onOpenFile(self) -> None:
         fileName, _ = QFileDialog.getOpenFileName(self, "Open File")
 
         if fileName:
             self.tabManager.setCurrentWidget(self.replayWindow)
             self.replayWindow.openFile(fileName)
 
-    def sendKeySequence(self, keys: [Qt.Key]):
+    def sendKeySequence(self, keys: [Qt.Key]) -> None:
         if self.tabManager.currentWidget() is self.liveWindow:
             self.liveWindow.sendKeySequence(keys)
 
-    def sendText(self):
+    def sendText(self) -> None:
         if self.tabManager.currentWidget() is not self.liveWindow:
             return
 
@@ -119,13 +119,13 @@ class MainWindow(QMainWindow):
 
         self.liveWindow.sendText(text)
 
-    def toggleFocusNewTab(self):
+    def toggleFocusNewTab(self) -> None:
         self.options["focusNewTab"] = not self.options.get("focusNewTab")
 
-    def togglecloseTabOnCtrlW(self):
+    def toggleCloseTabOnCtrlW(self) -> None:
         self.options["closeTabOnCtrlW"] = not self.options.get("closeTabOnCtrlW")
 
-    def updateTabConnectionCount(self):
+    def updateTabConnectionCount(self) -> None:
         """
         Update the first tab (Live connections) with the current number of tabs
         """

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -97,18 +97,18 @@ class MainWindow(QMainWindow):
         for fileName in filesToRead:
             self.replayWindow.openFile(fileName)
 
-    def onOpenFile(self) -> None:
+    def onOpenFile(self):
         fileName, _ = QFileDialog.getOpenFileName(self, "Open File")
 
         if fileName:
             self.tabManager.setCurrentWidget(self.replayWindow)
             self.replayWindow.openFile(fileName)
 
-    def sendKeySequence(self, keys: [Qt.Key]) -> None:
+    def sendKeySequence(self, keys: [Qt.Key]):
         if self.tabManager.currentWidget() is self.liveWindow:
             self.liveWindow.sendKeySequence(keys)
 
-    def sendText(self) -> None:
+    def sendText(self):
         if self.tabManager.currentWidget() is not self.liveWindow:
             return
 
@@ -119,13 +119,13 @@ class MainWindow(QMainWindow):
 
         self.liveWindow.sendText(text)
 
-    def toggleFocusNewTab(self) -> None:
+    def toggleFocusNewTab(self):
         self.options["focusNewTab"] = not self.options.get("focusNewTab")
 
-    def toggleCloseTabOnCtrlW(self) -> None:
+    def toggleCloseTabOnCtrlW(self):
         self.options["closeTabOnCtrlW"] = not self.options.get("closeTabOnCtrlW")
 
-    def updateTabConnectionCount(self) -> None:
+    def updateTabConnectionCount(self):
         """
         Update the first tab (Live connections) with the current number of tabs
         """

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -4,7 +4,7 @@
 # Licensed under the GPLv3 or later.
 #
 
-from PySide2.QtCore import Qt
+from PySide2.QtCore import Qt, Signal
 from PySide2.QtWidgets import QAction, QFileDialog, QMainWindow, QTabWidget, QInputDialog
 
 from pyrdp.player.LiveWindow import LiveWindow
@@ -16,6 +16,8 @@ class MainWindow(QMainWindow):
     Main window for the player application.
     """
 
+    updateCountSignal = Signal()
+
     def __init__(self, bind_address: str, port: int, filesToRead: [str]):
         """
         :param bind_address: address to bind to when listening for live connections.
@@ -24,19 +26,27 @@ class MainWindow(QMainWindow):
         """
         super().__init__()
 
-        self.liveWindow = LiveWindow(bind_address, port)
-        self.replayWindow = ReplayWindow()
+        # TODO : Rework into a class if we add more options later.
+        self.options = {
+            "focusNewTab": True,        # Useful whenever we are getting flooded with connections (or scanned), and we only want to monitor one at a time.
+            "closeTabOnCtrlW": True     # Allow user to toggle Ctrl+W passthrough.
+        }
 
+        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options)
+        self.replayWindow = ReplayWindow(self.options)
         self.tabManager = QTabWidget()
         self.tabManager.addTab(self.liveWindow, "Live connections")
         self.tabManager.addTab(self.replayWindow, "Replays")
         self.setCentralWidget(self.tabManager)
+        self.updateCountSignal.connect(self.updateTabConnectionCount)
 
+        # File menu
         openAction = QAction("Open...", self)
         openAction.setShortcut("Ctrl+O")
         openAction.setStatusTip("Open a replay file")
         openAction.triggered.connect(self.onOpenFile)
 
+        # Command menu
         windowsRAction = QAction("Windows+R", self)
         windowsRAction.setShortcut("Ctrl+Alt+R")
         windowsRAction.setStatusTip("Send a Windows+R key sequence")
@@ -57,6 +67,18 @@ class MainWindow(QMainWindow):
         typeTextAction.setStatusTip("Simulate typing on the keyboard")
         typeTextAction.triggered.connect(self.sendText)
 
+        # Options menu
+        focusTabAction = QAction("Focus new connections", self)
+        focusTabAction.setCheckable(True)
+        focusTabAction.setChecked(self.options.get("focusNewTab"))
+        focusTabAction.triggered.connect(lambda: self.toggleFocusNewTab())
+
+        closeTabOnCtrlW = QAction("Close current tab on Ctrl+W", self)
+        closeTabOnCtrlW.setCheckable(True)
+        closeTabOnCtrlW.setChecked(self.options.get("closeTabOnCtrlW"))
+        closeTabOnCtrlW.triggered.connect(lambda: self.togglecloseTabOnCtrlW())
+
+        # Create menu
         menuBar = self.menuBar()
 
         fileMenu = menuBar.addMenu("File")
@@ -67,6 +89,10 @@ class MainWindow(QMainWindow):
         commandMenu.addAction(windowsLAction)
         commandMenu.addAction(windowsEAction)
         commandMenu.addAction(typeTextAction)
+
+        optionsMenu = menuBar.addMenu("Options")
+        optionsMenu.addAction(focusTabAction)
+        optionsMenu.addAction(closeTabOnCtrlW)
 
         for fileName in filesToRead:
             self.replayWindow.openFile(fileName)
@@ -92,3 +118,16 @@ class MainWindow(QMainWindow):
             return
 
         self.liveWindow.sendText(text)
+
+    def toggleFocusNewTab(self):
+        self.options["focusNewTab"] = not self.options.get("focusNewTab")
+
+    def togglecloseTabOnCtrlW(self):
+        self.options["closeTabOnCtrlW"] = not self.options.get("closeTabOnCtrlW")
+
+    def updateTabConnectionCount(self):
+        """
+        Update the first tab (Live connections) with the current number of tabs
+        """
+
+        self.tabManager.setTabText(0, "Live connections (%d)" % self.liveWindow.count())

--- a/pyrdp/player/PlayerEventHandler.py
+++ b/pyrdp/player/PlayerEventHandler.py
@@ -6,6 +6,7 @@
 
 from typing import Optional, Union
 
+from PySide2.QtCore import QObject
 from PySide2.QtGui import QTextCursor
 from PySide2.QtWidgets import QTextEdit
 
@@ -22,7 +23,7 @@ from pyrdp.player import keyboard
 from pyrdp.ui import QRemoteDesktop, RDPBitmapToQtImage
 
 
-class PlayerEventHandler(Observer):
+class PlayerEventHandler(QObject, Observer):
     """
     Class to handle events coming to the player.
     """

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -4,8 +4,9 @@
 # Licensed under the GPLv3 or later.
 #
 
-from PySide2.QtGui import QKeySequence
-from PySide2.QtWidgets import QShortcut, QWidget
+from typing import Dict
+
+from PySide2.QtWidgets import QWidget
 
 from pyrdp.player.BaseWindow import BaseWindow
 from pyrdp.player.ReplayTab import ReplayTab
@@ -16,9 +17,8 @@ class ReplayWindow(BaseWindow):
     Class for managing replay tabs.
     """
 
-    def __init__(self, parent: QWidget = None):
-        super().__init__(parent)
-        self.closeTabShortcut = QShortcut(QKeySequence("Ctrl+W"), self, self.closeCurrentTab)
+    def __init__(self, options: Dict[str, object], parent: QWidget = None):
+        super().__init__(options, parent)
 
     def openFile(self, fileName: str):
         """
@@ -28,7 +28,3 @@ class ReplayWindow(BaseWindow):
         tab = ReplayTab(fileName)
         self.addTab(tab, fileName)
         self.log.debug("Loading replay file %(arg1)s", {"arg1": fileName})
-
-    def closeCurrentTab(self):
-        if self.count() > 0:
-            self.onTabClosed(self.currentIndex())


### PR DESCRIPTION
After using the live pyrdp-player for a few days, with multiple inbound connections at the same time, I had a few improvement ideas :

- Give the new tabs a meaningful name (pyrdp codename or hostname)
- Be clear about which connections are still active, without having to scroll down the log.

The onDisconnection hook wasn't used correctly, so I've removed it, and I added a new rename hook. I rename a tab whenever we receive the clientDataPDU, and on client disconnection. I don't really like using Signals() for that, but it seems common in Qt. Let me know what you think.