### PR TITLE
Fixed a case where DOSName had no nullbyte

### DIFF
--- a/pyrdp/parser/rdp/virtual_channel/device_redirection.py
+++ b/pyrdp/parser/rdp/virtual_channel/device_redirection.py
@@ -144,11 +144,10 @@ class DeviceRedirectionParser(Parser):
 
         preferredDOSName = preferredDOSName.decode(errors = "ignore")[: 7]
 
-        endIndex = -1
         try:
             endIndex = preferredDOSName.index("\x00")
-        except:
-            pass
+        except ValueError:
+            endIndex = -1
 
         if endIndex >= 0:
             preferredDOSName = preferredDOSName[: endIndex]

--- a/pyrdp/parser/rdp/virtual_channel/device_redirection.py
+++ b/pyrdp/parser/rdp/virtual_channel/device_redirection.py
@@ -143,7 +143,12 @@ class DeviceRedirectionParser(Parser):
         deviceData = stream.read(deviceDataLength)
 
         preferredDOSName = preferredDOSName.decode(errors = "ignore")[: 7]
-        endIndex = preferredDOSName.index("\x00")
+
+        endIndex = -1
+        try:
+            endIndex = preferredDOSName.index("\x00")
+        except:
+            pass
 
         if endIndex >= 0:
             preferredDOSName = preferredDOSName[: endIndex]


### PR DESCRIPTION
Attempts a fix for #120. From my two use case, this fixes it.

Documentation regarding preferredDOSName :
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpepc/993fd26f-b31b-4524-90ec-3efb59445f2a