### PR TITLE
Added client's IP and clientData to allow client identification

### DIFF
--- a/pyrdp/layer/tcp.py
+++ b/pyrdp/layer/tcp.py
@@ -57,7 +57,14 @@ class TwistedTCPLayer(IntermediateLayer, Protocol):
         When the TCP handshake is completed, notify the observer.
         """
         self.connectedEvent.set()
-        self.observer.onConnection()
+
+        try:
+            # Connection to client
+            ip = self.transport.client[0]
+            self.observer.onConnection(ip)
+        except AttributeError:
+            # Connection to server / attacker
+            self.observer.onConnection()
 
     def connectionLost(self, reason=connectionDone):
         """

--- a/pyrdp/layer/tcp.py
+++ b/pyrdp/layer/tcp.py
@@ -57,14 +57,7 @@ class TwistedTCPLayer(IntermediateLayer, Protocol):
         When the TCP handshake is completed, notify the observer.
         """
         self.connectedEvent.set()
-
-        try:
-            # Connection to client
-            ip = self.transport.client[0]
-            self.observer.onConnection(ip)
-        except AttributeError:
-            # Connection to server / attacker
-            self.observer.onConnection()
+        self.observer.onConnection()
 
     def connectionLost(self, reason=connectionDone):
         """

--- a/pyrdp/mitm/TCPMITM.py
+++ b/pyrdp/mitm/TCPMITM.py
@@ -62,12 +62,13 @@ class TCPMITM:
         self.client.removeObserver(self.clientObserver)
         self.server.removeObserver(self.serverObserver)
 
-    def onClientConnection(self, ip):
+    def onClientConnection(self):
         """
         Log the fact that a new client has connected.
         """
         self.connectionTime = time.time()
-        self.log.info("New client connected from %(client_ip)s", {"client_ip": ip})
+        ip = self.client.transport.client[0]
+        self.log.info("New client connected from %(clientIp)s", {"clientIp": ip})
 
     def onClientDisconnection(self, reason):
         """

--- a/pyrdp/mitm/TCPMITM.py
+++ b/pyrdp/mitm/TCPMITM.py
@@ -62,12 +62,12 @@ class TCPMITM:
         self.client.removeObserver(self.clientObserver)
         self.server.removeObserver(self.serverObserver)
 
-    def onClientConnection(self):
+    def onClientConnection(self, ip):
         """
         Log the fact that a new client has connected.
         """
         self.connectionTime = time.time()
-        self.log.info("New client connected")
+        self.log.info("New client connected from %(client_ip)s", {"client_ip": ip})
 
     def onClientDisconnection(self, reason):
         """

--- a/pyrdp/mitm/mitm.py
+++ b/pyrdp/mitm/mitm.py
@@ -90,7 +90,7 @@ class RDPMITM:
         self.x224 = X224MITM(self.client.x224, self.server.x224, self.getLog("x224"), self.state, serverConnector, self.startTLS)
         """X224 MITM component"""
 
-        self.mcs = MCSMITM(self.client.mcs, self.server.mcs, self.state, self.recorder, self.buildChannel)
+        self.mcs = MCSMITM(self.client.mcs, self.server.mcs, self.state, self.recorder, self.buildChannel, self.getLog("mcs"))
         """MCS MITM component"""
 
         self.security: SecurityMITM = None


### PR DESCRIPTION
Fixes #122 . I also log clientData, which normally is the hostname, but tools use it to identify "what" did the connection, just like an user-agent.