### PR TITLE
Added logger to TwisterTCPLayer for error handling and made PyRDP more "scanner compliant"

### DIFF
--- a/pyrdp/layer/tcp.py
+++ b/pyrdp/layer/tcp.py
@@ -42,6 +42,7 @@ class TwistedTCPLayer(IntermediateLayer, Protocol):
     """
 
     def __init__(self):
+        self.log = logging.getLogger(LOGGER_NAMES.PYRDP)
         super().__init__(TCPParser())
         self.connectedEvent = asyncio.Event()
         self.logSSLRequired = False
@@ -91,9 +92,8 @@ class TwistedTCPLayer(IntermediateLayer, Protocol):
         except KeyboardInterrupt:
             raise
         except Exception as e:
-            log = logging.getLogger(LOGGER_NAMES.PYRDP)
-            log.exception(e)
-            log.error("Exception occurred when receiving: %(data)s" , {"data": hexlify(data).decode()})
+            self.log.exception(e)
+            self.log.error("Exception occurred when receiving: %(data)s" , {"data": hexlify(data).decode()})
             raise
 
     def sendBytes(self, data: bytes):

--- a/pyrdp/mitm/TCPMITM.py
+++ b/pyrdp/mitm/TCPMITM.py
@@ -39,6 +39,10 @@ class TCPMITM:
         self.recorder = recorder
         self.serverConnector = serverConnector
 
+        # Allows a lower layer to raise error tagged with the correct sessionID
+        self.client.log = log
+        self.server.log = log
+
         self.clientObserver = self.client.createObserver(
             onConnection = self.onClientConnection,
             onDisconnection = self.onClientDisconnection,

--- a/pyrdp/parser/rdp/connection.py
+++ b/pyrdp/parser/rdp/connection.py
@@ -110,7 +110,10 @@ class ClientConnectionParser(Parser):
             core.postBeta2ColorDepth = Uint16LE.unpack(stream)
             core.clientProductId = Uint16LE.unpack(stream)
             core.serialNumber = Uint32LE.unpack(stream)
-            core.highColorDepth = HighColorDepth(Uint16LE.unpack(stream))
+
+            # Should match HighColorDepth enum most of the time, but in order to support scanners and we script, we have to loosely accept this one
+            # Anyway, the server will reject it and enforce another one
+            core.highColorDepth = Uint16LE.unpack(stream)
             core.supportedColorDepths = Uint16LE.unpack(stream)
             core.earlyCapabilityFlags = Uint16LE.unpack(stream)
             core.clientDigProductId = decodeUTF16LE(stream.read(64))


### PR DESCRIPTION
Errors are now correctly tagged with the correct sessionID instead of global.

I also removed the enum HighColorDepth from the coreDataPDU since most scanners and scripts use a non-valid value. It serves no real purpose since the server respond to a bad HighColorDepth by enforcing another one.