### PR TITLE
Update Linux Installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ _Note: PyRDP cannot be installed on 32bit systems. See: [this issue.](https://gi
 First, make sure to install the prerequisite packages (on Ubuntu):
 
 ```
-sudo apt install libdbus-1-dev libdbus-glib-1-dev
+sudo apt install libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx
 ```
 
 On some systems, you may need to install the `python3-venv` package:


### PR DESCRIPTION
Added a package libgl1-mesa-glx to the Ubuntu Linux installation requirements. This solves the issue of getting error "ImportError: libGL.so.1: cannot open shared object file: No such file or directory" upon running pyrdp-mitm.py. Note that I downloaded and installed this repo on a clean Ubuntu 18.04.3 LTS installation on Azure.