### PR TITLE
Feat: Add option to allow GDI draw orders through the MITM

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Further Docker image size improvements ({uri-issue}173[#173] and more)
 * Default Docker Compose command now `pyrdp-mitm -h` to avoid confusing crash on `docker-compose up` ({uri-issue}173[#173])
 * Documentation updates and fixes ({uri-issue}165[#165], {uri-issue}166[#166], {uri-issue}172[#172])
+* Added `--gdi` switch to let video passthrough (this switch is not compatible with pyrdp-player) ({uri-issue}50[#50])
 
 === Bug fixes
 

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -48,6 +48,7 @@ def main():
     parser.add_argument("--crawler-match-file", help="File to be used by the crawler to chose what to download when scraping the client shared drives.", default=None)
     parser.add_argument("--crawler-ignore-file", help="File to be used by the crawler to chose what folders to avoid when scraping the client shared drives.", default=None)
     parser.add_argument("--no-replay", help="Disable replay recording", action="store_true")
+    parser.add_argument("--gdi", help="Allow GDI passthrough (No video decoding)", action="store_true")
 
     args = parser.parse_args()
     outDir = Path(args.output)
@@ -75,6 +76,7 @@ def main():
     config.crawlerMatchFileName = args.crawler_match_file
     config.crawlerIgnoreFileName = args.crawler_ignore_file
     config.recordReplays = not args.no_replay
+    config.allowGDI = args.gdi
 
 
     payload = None

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -70,7 +70,7 @@ class RDPMITM:
         self.statCounter = StatCounter()
         """Class to keep track of connection-related statistics such as # of mouse events, # of output events, etc."""
 
-        self.state = RDPMITMState()
+        self.state = RDPMITMState(self.config)
         """The MITM state"""
 
         self.client = RDPLayerSet()

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -41,6 +41,13 @@ class MITMConfig:
         self.outDir: Path = None
         """The output directory"""
 
+        self.allowGDI: bool = False
+        """
+        Whether to let the video channel pass through unintercepted.
+        This can greatly increase performance and avoid fingerprinting
+        at the cost of being unable to record or view the screen.
+        """
+
         self.recordReplays: bool = True
         """Whether replays should be recorded or not"""
 

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -20,9 +20,11 @@ class RDPMITMState:
     State object for the RDP MITM. This is for data that needs to be shared across components.
     """
 
-    def __init__(self):
+    def __init__(self, config):
         self.requestedProtocols: Optional[NegotiationProtocols] = None
         """The original request protocols"""
+
+        self.config = config
 
         self.useTLS = False
         """Whether the connection uses TLS or not"""

--- a/twisted/plugins/pyrdp_plugin.py
+++ b/twisted/plugins/pyrdp_plugin.py
@@ -38,6 +38,8 @@ class Options(usage.Options):
         ["sensor-id", "s", "PyRDP", "Sensor ID (to differentiate multiple instances "
                                     "of the MITM where logs are aggregated at one place)"]]
 
+    optFlags = [["gdi", None, 'Allows GDI passthrough']]
+
 
 @implementer(IServiceMaker, IPlugin)
 class PyRdpMitmServiceMaker(object):
@@ -61,6 +63,7 @@ class PyRdpMitmServiceMaker(object):
         targetHost, targetPort = parseTarget(options["target"])
         config.targetHost = targetHost
         config.targetPort = targetPort
+        config.allowGdi = options["gdi"]
 
         key, certificate = validateKeyAndCertificate(options["private-key"],
                                                      options["certificate"])


### PR DESCRIPTION
This feature adds a `--gdi` option to `pyrdp-mitm` that disables bitmap downgrade and lets the data through undecoded.

This is the first step towards supporting MS-RDPEGDI extensions in PyRDP and should hopefully help with honeypot fingerprinting. It has the side-effect that video cannot be viewed by the player, but keylogging, file crawling, and clipboard stealing all work.