### PR TITLE
Add a CLI argument to disable active clipboard stealing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ docs/*.html
 
 # pyrdp-specific
 pyrdp_output/
+*.cert
+*.pyrdp
+*.log
+*.key
+mitm.json
 
 # twisted
 /twisted/plugins/dropin.cache

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 
+import argparse
 #
 # This file is part of the PyRDP project.
 # Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 import asyncio
-import argparse
 import logging
 import os
 import sys
-from pathlib import Path
 from base64 import b64encode
+from pathlib import Path
 
 # need to install this reactor before importing other twisted code
 from twisted.internet import asyncioreactor
+
 asyncioreactor.install(asyncio.get_event_loop())
 
 from twisted.internet import reactor
@@ -44,6 +45,7 @@ def main():
     parser.add_argument("--payload-powershell-file", help="PowerShell script to run automatically upon connection (as -EncodedCommand)", default=None)
     parser.add_argument("--payload-delay", help="Time to wait after a new connection before sending the payload, in milliseconds", default=None)
     parser.add_argument("--payload-duration", help="Amount of time for which input / output should be dropped, in milliseconds. This can be used to hide the payload screen.", default=None)
+    parser.add_argument("--disable-active-clipboard", help="Disables the active clipboard stealing to request clipboard content upon connection.", action="store_true")
     parser.add_argument("--crawl", help="Enable automatic shared drive scraping", action="store_true")
     parser.add_argument("--crawler-match-file", help="File to be used by the crawler to chose what to download when scraping the client shared drives.", default=None)
     parser.add_argument("--crawler-ignore-file", help="File to be used by the crawler to chose what folders to avoid when scraping the client shared drives.", default=None)
@@ -75,6 +77,7 @@ def main():
     config.crawlerMatchFileName = args.crawler_match_file
     config.crawlerIgnoreFileName = args.crawler_ignore_file
     config.recordReplays = not args.no_replay
+    config.disableActiveClipboardStealing = args.disable_active_clipboard
 
 
     payload = None

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-import argparse
 #
 # This file is part of the PyRDP project.
 # Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
+import argparse
 import asyncio
 import logging
 import os
@@ -15,7 +15,6 @@ from pathlib import Path
 
 # need to install this reactor before importing other twisted code
 from twisted.internet import asyncioreactor
-
 asyncioreactor.install(asyncio.get_event_loop())
 
 from twisted.internet import reactor

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -62,6 +62,9 @@ class MITMConfig:
         self.crawlerIgnoreFileName: str = None
         """Path to the crawler ignore configuration file"""
 
+        self.disableActiveClipboardStealing: bool = False
+        """ If set to False, use PassiveClipboardStealer instead of ActiveClipboardStealer."""
+
     @property
     def replayDir(self) -> Path:
         """

--- a/twisted/plugins/pyrdp_plugin.py
+++ b/twisted/plugins/pyrdp_plugin.py
@@ -4,11 +4,11 @@
 # Licensed under the GPLv3 or later.
 #
 import asyncio
-import logging
 from pathlib import Path
 
 # need to install this reactor before importing other twisted code
 from twisted.internet import asyncioreactor
+
 asyncioreactor.install(asyncio.get_event_loop())
 
 from twisted.python import usage
@@ -37,6 +37,7 @@ class Options(usage.Options):
         ["log-filter", "F", "", "Only show logs from this logger name (accepts '*' wildcards)"],
         ["sensor-id", "s", "PyRDP", "Sensor ID (to differentiate multiple instances "
                                     "of the MITM where logs are aggregated at one place)"]]
+    optFlags = [["disable-active-clipboard", None, "Disables the active clipboard stealing to request clipboard content upon connection."]]
 
 
 @implementer(IServiceMaker, IPlugin)
@@ -61,6 +62,8 @@ class PyRdpMitmServiceMaker(object):
         targetHost, targetPort = parseTarget(options["target"])
         config.targetHost = targetHost
         config.targetPort = targetPort
+
+        config.disableActiveClipboardStealing = options["disable-active-clipboard"]
 
         key, certificate = validateKeyAndCertificate(options["private-key"],
                                                      options["certificate"])


### PR DESCRIPTION
uses only passive stealing instead

- Add pyrdp-generated files to .gitignore

Tested using mstsc.exe on win 10 to a win7 target machine