### PR TITLE
feat: Added `--no-downgrade` mode.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,7 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Default Docker Compose command now `pyrdp-mitm -h` to avoid confusing crash on `docker-compose up` ({uri-issue}173[#173])
 * Documentation updates and fixes ({uri-issue}165[#165], {uri-issue}166[#166], {uri-issue}172[#172])
 * Added `--disable-active-clipboard` switch to prevent clipboard request injection
-* Added `--no-downgrade` switch to prevent protocol downgrading where possible.
+* Added `--no-downgrade` switch to prevent protocol downgrading where possible {uri-issue}189[#189]
 
 
 === Bug fixes

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Default Docker Compose command now `pyrdp-mitm -h` to avoid confusing crash on `docker-compose up` ({uri-issue}173[#173])
 * Documentation updates and fixes ({uri-issue}165[#165], {uri-issue}166[#166], {uri-issue}172[#172])
 * Added `--disable-active-clipboard` switch to prevent clipboard request injection
+* Added `--no-downgrade` switch to prevent protocol downgrading where possible.
 
 
 === Bug fixes

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In August 2019, PyRDP was demo'ed at BlackHat Arsenal ([slides](https://docs.goo
       - [Choosing when to start the payload](#choosing-when-to-start-the-payload)
       - [Choosing when to resume normal activity](#choosing-when-to-resume-normal-activity)
     + [Other MITM arguments](#other-mitm-arguments)
+      - [--no-downgrade](#--no-downgrade)
   * [Using the PyRDP Player](#using-the-pyrdp-player)
     + [Playing a replay file](#playing-a-replay-file)
     + [Listening for live connections](#listening-for-live-connections)

--- a/README.md
+++ b/README.md
@@ -306,6 +306,30 @@ After 5 seconds, input / output is restored back to normal.
 #### Other MITM arguments
 Run `pyrdp-mitm.py --help` for a full list of arguments.
 
+##### `--no-downgrade`
+
+This argument is useful when running PyRDP in Honeypot scenarios to avoid scanner fingerprinting.
+When the switch is enabled, PyRDP will not downgrade unsupported extensions and let them the traffic through
+transparently. The player will likely not be able to successfully replay video traffic, but the following supported
+channels should still be accessible:
+
+- Keystroke recording
+- Mouse position updates
+- Clipboard access (passively)
+- Drive access (passively)
+
+This feature is still a work in progress and some downgrades are currently unavoidable to allow the connection 
+to be established. The following downgrades are currently not affected by this switch and will still happen:
+
+- FIPS Encryption
+- Non-TLS encryption protocols
+- ClientInfo compression
+- Virtual Channel compression
+
+If being able to eventually replay the full session is important, a good solution is to record the raw RDP traffic
+using Wireshark and keep the TLS master secrets. Whenever PyRDP adds support for additional extensions, it would
+then become possible to extract a valid RDP replay file from the raw network capture.
+
 ### Using the PyRDP Player
 Use `pyrdp-player.py` to run the player.
 

--- a/README.md
+++ b/README.md
@@ -309,26 +309,26 @@ Run `pyrdp-mitm.py --help` for a full list of arguments.
 ##### `--no-downgrade`
 
 This argument is useful when running PyRDP in Honeypot scenarios to avoid scanner fingerprinting.
-When the switch is enabled, PyRDP will not downgrade unsupported extensions and let them the traffic through
-transparently. The player will likely not be able to successfully replay video traffic, but the following supported
-channels should still be accessible:
+When the switch is enabled, PyRDP will not downgrade unsupported extensions and let the traffic through
+transparently. The player will likely not be able to successfully replay video traffic, but the following 
+supported channels should still be accessible:
 
 - Keystroke recording
 - Mouse position updates
 - Clipboard access (passively)
 - Drive access (passively)
 
-This feature is still a work in progress and some downgrades are currently unavoidable to allow the connection 
-to be established. The following downgrades are currently not affected by this switch and will still happen:
+This feature is still a work in progress and some downgrading is currently unavoidable to allow the connection 
+to be established. The following are currently not affected by this switch and will still be disabled:
 
 - FIPS Encryption
 - Non-TLS encryption protocols
 - ClientInfo compression
 - Virtual Channel compression
 
-If being able to eventually replay the full session is important, a good solution is to record the raw RDP traffic
-using Wireshark and keep the TLS master secrets. Whenever PyRDP adds support for additional extensions, it would
-then become possible to extract a valid RDP replay file from the raw network capture.
+**NOTE**: If being able to eventually replay the full session is important, a good solution is to record the raw 
+RDP traffic using Wireshark and keep the TLS master secrets. Whenever PyRDP adds support for additional extensions, 
+it would then become possible to extract a valid RDP replay file from the raw network capture.
 
 ### Using the PyRDP Player
 Use `pyrdp-player.py` to run the player.

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -49,6 +49,7 @@ def main():
     parser.add_argument("--crawler-match-file", help="File to be used by the crawler to chose what to download when scraping the client shared drives.", default=None)
     parser.add_argument("--crawler-ignore-file", help="File to be used by the crawler to chose what folders to avoid when scraping the client shared drives.", default=None)
     parser.add_argument("--no-replay", help="Disable replay recording", action="store_true")
+    parser.add_argument("--no-downgrade", help="Disables downgrading of unsupported extensions. This makes PyRDP harder to fingerprint but might impact the player's ability to replay captured traffic.", action="store_true")
 
     args = parser.parse_args()
     outDir = Path(args.output)
@@ -76,6 +77,7 @@ def main():
     config.crawlerMatchFileName = args.crawler_match_file
     config.crawlerIgnoreFileName = args.crawler_ignore_file
     config.recordReplays = not args.no_replay
+    config.downgrade = not args.no_downgrade
     config.disableActiveClipboardStealing = args.disable_active_clipboard
 
 

--- a/pyrdp/mitm/MCSMITM.py
+++ b/pyrdp/mitm/MCSMITM.py
@@ -88,22 +88,23 @@ class MCSMITM:
         rdpClientDataPDU.securityData.encryptionMethods &= ~EncryptionMethod.ENCRYPTION_FIPS
         rdpClientDataPDU.securityData.extEncryptionMethods &= ~EncryptionMethod.ENCRYPTION_FIPS
 
-        #  This disables the support for the Graphics pipeline extension, which is a completely different way to
-        #  transfer graphics from server to client. https://msdn.microsoft.com/en-us/library/dn366933.aspx
-        rdpClientDataPDU.coreData.earlyCapabilityFlags &= ~ClientCapabilityFlag.RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL
+        if not self.state.config.downgrade:
+            #  This disables the support for the Graphics pipeline extension, which is a completely different way to
+            #  transfer graphics from server to client. https://msdn.microsoft.com/en-us/library/dn366933.aspx
+            rdpClientDataPDU.coreData.earlyCapabilityFlags &= ~ClientCapabilityFlag.RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL
 
-        #  Remove 24bpp and 32bpp support, fall back to 16bpp.
-        #  2018-12-14: This is only there because there is a bug in the pyrdp player where 24bpp
-        #  decompression in rle.c causes random crashes. If this bug is fixed, we could remove this.
-        rdpClientDataPDU.coreData.supportedColorDepths &= ~SupportedColorDepth.RNS_UD_32BPP_SUPPORT
-        rdpClientDataPDU.coreData.supportedColorDepths &= ~SupportedColorDepth.RNS_UD_24BPP_SUPPORT
-        rdpClientDataPDU.coreData.highColorDepth &= ~HighColorDepth.HIGH_COLOR_24BPP
+            #  Remove 24bpp and 32bpp support, fall back to 16bpp.
+            #  2018-12-14: This is only there because there is a bug in the pyrdp player where 24bpp
+            #  decompression in rle.c causes random crashes. If this bug is fixed, we could remove this.
+            rdpClientDataPDU.coreData.supportedColorDepths &= ~SupportedColorDepth.RNS_UD_32BPP_SUPPORT
+            rdpClientDataPDU.coreData.supportedColorDepths &= ~SupportedColorDepth.RNS_UD_24BPP_SUPPORT
+            rdpClientDataPDU.coreData.highColorDepth &= ~HighColorDepth.HIGH_COLOR_24BPP
 
-        if rdpClientDataPDU.coreData.highColorDepth == 0:
-            # Means the requested color depth was 24bpp, fallback to 16bpp
-            rdpClientDataPDU.coreData.highColorDepth |= HighColorDepth.HIGH_COLOR_16BPP
+            if rdpClientDataPDU.coreData.highColorDepth == 0:
+                # Means the requested color depth was 24bpp, fallback to 16bpp
+                rdpClientDataPDU.coreData.highColorDepth |= HighColorDepth.HIGH_COLOR_16BPP
 
-        rdpClientDataPDU.coreData.earlyCapabilityFlags &= ~ClientCapabilityFlag.RNS_UD_CS_WANT_32BPP_SESSION
+            rdpClientDataPDU.coreData.earlyCapabilityFlags &= ~ClientCapabilityFlag.RNS_UD_CS_WANT_32BPP_SESSION
 
         self.recorder.record(rdpClientDataPDU, PlayerPDUType.CLIENT_DATA)
 

--- a/pyrdp/mitm/MCSMITM.py
+++ b/pyrdp/mitm/MCSMITM.py
@@ -88,7 +88,7 @@ class MCSMITM:
         rdpClientDataPDU.securityData.encryptionMethods &= ~EncryptionMethod.ENCRYPTION_FIPS
         rdpClientDataPDU.securityData.extEncryptionMethods &= ~EncryptionMethod.ENCRYPTION_FIPS
 
-        if not self.state.config.downgrade:
+        if self.state.config.downgrade:
             #  This disables the support for the Graphics pipeline extension, which is a completely different way to
             #  transfer graphics from server to client. https://msdn.microsoft.com/en-us/library/dn366933.aspx
             rdpClientDataPDU.coreData.earlyCapabilityFlags &= ~ClientCapabilityFlag.RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -72,7 +72,7 @@ class RDPMITM:
         self.statCounter = StatCounter()
         """Class to keep track of connection-related statistics such as # of mouse events, # of output events, etc."""
 
-        self.state = RDPMITMState()
+        self.state = RDPMITMState(config)
         """The MITM state"""
 
         self.client = RDPLayerSet()

--- a/pyrdp/mitm/SlowPathMITM.py
+++ b/pyrdp/mitm/SlowPathMITM.py
@@ -59,21 +59,22 @@ class SlowPathMITM(BasePathMITM):
         :param pdu: the confirm active PDU
         """
 
-        # Force RDP server to send bitmap events instead of order events.
-        pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderFlags = OrderFlag.NEGOTIATEORDERSUPPORT | OrderFlag.ZEROBOUNDSDELTASSUPPORT
-        pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderSupport = b"\x00" * 32
-
         # Disable virtual channel compression
         if CapabilityType.CAPSTYPE_VIRTUALCHANNEL in pdu.parsedCapabilitySets:
             pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_VIRTUALCHANNEL].flags = VirtualChannelCompressionFlag.VCCAPS_NO_COMPR
 
-        # Override the bitmap cache capability set with null values.
-        if CapabilityType.CAPSTYPE_BITMAPCACHE in pdu.parsedCapabilitySets:
-            pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_BITMAPCACHE] = Capability(CapabilityType.CAPSTYPE_BITMAPCACHE, b"\x00" * 36)
+        if not self.state.config.downgrade:
+            # Force RDP server to send bitmap events instead of order events.
+            pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderFlags = OrderFlag.NEGOTIATEORDERSUPPORT | OrderFlag.ZEROBOUNDSDELTASSUPPORT
+            pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderSupport = b"\x00" * 32
 
-        # Disable surface commands
-        if CapabilityType.CAPSETTYPE_SURFACE_COMMANDS in pdu.parsedCapabilitySets:
-            pdu.parsedCapabilitySets[CapabilityType.CAPSETTYPE_SURFACE_COMMANDS].cmdFlags = 0
+            # Override the bitmap cache capability set with null values.
+            if CapabilityType.CAPSTYPE_BITMAPCACHE in pdu.parsedCapabilitySets:
+                pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_BITMAPCACHE] = Capability(CapabilityType.CAPSTYPE_BITMAPCACHE, b"\x00" * 36)
+
+            # Disable surface commands
+            if CapabilityType.CAPSETTYPE_SURFACE_COMMANDS in pdu.parsedCapabilitySets:
+                pdu.parsedCapabilitySets[CapabilityType.CAPSETTYPE_SURFACE_COMMANDS].cmdFlags = 0
 
     def onDemandActive(self, pdu: DemandActivePDU):
         """

--- a/pyrdp/mitm/SlowPathMITM.py
+++ b/pyrdp/mitm/SlowPathMITM.py
@@ -63,7 +63,7 @@ class SlowPathMITM(BasePathMITM):
         if CapabilityType.CAPSTYPE_VIRTUALCHANNEL in pdu.parsedCapabilitySets:
             pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_VIRTUALCHANNEL].flags = VirtualChannelCompressionFlag.VCCAPS_NO_COMPR
 
-        if not self.state.config.downgrade:
+        if self.state.config.downgrade:
             # Force RDP server to send bitmap events instead of order events.
             pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderFlags = OrderFlag.NEGOTIATEORDERSUPPORT | OrderFlag.ZEROBOUNDSDELTASSUPPORT
             pdu.parsedCapabilitySets[CapabilityType.CAPSTYPE_ORDER].orderSupport = b"\x00" * 32

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -44,6 +44,9 @@ class MITMConfig:
         self.recordReplays: bool = True
         """Whether replays should be recorded or not"""
 
+        self.downgrade: bool = True
+        """Whether to actively downgrade unsupported extensions."""
+
         self.payload: str = ""
         """Payload to send automatically upon connection"""
 

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -13,6 +13,7 @@ from pyrdp.layer import FastPathLayer, SecurityLayer, TLSSecurityLayer
 from pyrdp.parser import createFastPathParser
 from pyrdp.pdu import ClientChannelDefinition
 from pyrdp.security import RC4CrypterProxy, SecuritySettings
+from pyrdp.mitm.config import MITMConfig
 
 
 class RDPMITMState:
@@ -20,9 +21,12 @@ class RDPMITMState:
     State object for the RDP MITM. This is for data that needs to be shared across components.
     """
 
-    def __init__(self):
+    def __init__(self, config: MITMConfig):
         self.requestedProtocols: Optional[NegotiationProtocols] = None
         """The original request protocols"""
+
+        self.config = config
+        """The MITM configuration."""
 
         self.useTLS = False
         """Whether the connection uses TLS or not"""
@@ -93,5 +97,6 @@ class RDPMITMState:
         :param mode: the mode of the layer (client or server)
         """
 
-        parser = createFastPathParser(self.useTLS, self.securitySettings.encryptionMethod, self.crypters[mode], mode)
+        parser = createFastPathParser(
+            self.useTLS, self.securitySettings.encryptionMethod, self.crypters[mode], mode)
         return FastPathLayer(parser)


### PR DESCRIPTION
This is a rework of the `--gdi-passthrough` branch that covers a broader set of passthrough options.

After some internal discussion, a mode that avoids fingerprinting by not downgrading any of the connection features makes more sense than per-extension support switches, so I renamed the switch to `--no-downgrade` and added some documentation to explain its current state, what it can and cannot do, and its impacts on the PyRDP player.