### PR TITLE
feat: Add support for logging configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ PyRDP was [introduced in 2018](https://www.gosecure.net/blog/2018/12/19/rdp-man-
     + [Cloning a certificate](#cloning-a-certificate)
     + [Using a custom private key](#using-a-custom-private-key)
     + [Other cloner arguments](#other-cloner-arguments)
+  * [Configuring PyRDP](#configuring-pyrdp)
   * [Using PyRDP as a Library](#using-pyrdp-as-a-library)
   * [Using PyRDP with twistd](#using-pyrdp-with-twistd)
   * [Using PyRDP with Bettercap](#using-pyrdp-with-bettercap)
@@ -386,6 +387,17 @@ pyrdp-clonecert.py 192.168.1.10 cert.pem -i input_key.pem
 
 #### Other cloner arguments
 Run `pyrdp-clonecert.py --help` for a full list of arguments.
+
+### Configuring PyRDP
+
+Most of the PyRDP configurations are done through command line switches, but it is also possible to use a
+configuration file for certain settings such as log configuration.
+
+The default configuration files used by PyRDP are located in [mitm.default.ini](pyrdp/mitm/mitm.default.ini)
+and [player.default.ini](pyrdp/player/player.default.ini). Both files are thoroughly documented and can serve
+as a basis for further configuration.
+
+In the future there are plans to support other aspects of PyRDP configuration through those configuration files.
 
 ### Using PyRDP as a Library
 If you're interested in experimenting with RDP and making your own tools, head over to our

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -5,178 +5,32 @@
 # Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
-import argparse
 import asyncio
 import logging
-import os
-import sys
-from base64 import b64encode
-from pathlib import Path
 
-# need to install this reactor before importing other twisted code
+# Need to install this reactor before importing other twisted code
 from twisted.internet import asyncioreactor
 asyncioreactor.install(asyncio.get_event_loop())
-
 from twisted.internet import reactor
 
 from pyrdp.core import settings
 from pyrdp.core.mitm import MITMServerFactory
 from pyrdp.mitm import MITMConfig, DEFAULTS
-from pyrdp.mitm.cli import logConfiguration, parseTarget, validateKeyAndCertificate
-from pyrdp.logging import configure as configureLoggers, LOGGER_NAMES
+from pyrdp.mitm.cli import showConfiguration, configure
+from pyrdp.logging import LOGGER_NAMES
 
 
 def main():
-    # Warning: keep in sync with twisted/plugins/pyrdp_plugin.py
-    parser = argparse.ArgumentParser()
-    parser.add_argument("target", help="IP:port of the target RDP machine (ex: 192.168.1.10:3390)")
-    parser.add_argument("-l", "--listen", help="Port number to listen on (default: 3389)", default=3389)
-    parser.add_argument("-o", "--output", help="Output folder", default="pyrdp_output")
-    parser.add_argument("-i", "--destination-ip", help="Destination IP address of the PyRDP player.If not specified, RDP events are not sent over the network.")
-    parser.add_argument("-d", "--destination-port", help="Listening port of the PyRDP player (default: 3000).", default=3000)
-    parser.add_argument("-k", "--private-key", help="Path to private key (for SSL)")
-    parser.add_argument("-c", "--certificate", help="Path to certificate (for SSL)")
-    parser.add_argument("-u", "--username", help="Username that will replace the client's username", default=None)
-    parser.add_argument("-p", "--password", help="Password that will replace the client's password", default=None)
-    parser.add_argument("-L", "--log-level", help="Console logging level. Logs saved to file are always verbose.", default="INFO", choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
-    parser.add_argument("-F", "--log-filter", help="Only show logs from this logger name (accepts '*' wildcards)", default="")
-    parser.add_argument("-s", "--sensor-id", help="Sensor ID (to differentiate multiple instances of the MITM where logs are aggregated at one place)", default="PyRDP")
-    parser.add_argument("--payload", help="Command to run automatically upon connection", default=None)
-    parser.add_argument("--payload-powershell", help="PowerShell command to run automatically upon connection", default=None)
-    parser.add_argument("--payload-powershell-file", help="PowerShell script to run automatically upon connection (as -EncodedCommand)", default=None)
-    parser.add_argument("--payload-delay", help="Time to wait after a new connection before sending the payload, in milliseconds", default=None)
-    parser.add_argument("--payload-duration", help="Amount of time for which input / output should be dropped, in milliseconds. This can be used to hide the payload screen.", default=None)
-    parser.add_argument("--disable-active-clipboard", help="Disables the active clipboard stealing to request clipboard content upon connection.", action="store_true")
-    parser.add_argument("--crawl", help="Enable automatic shared drive scraping", action="store_true")
-    parser.add_argument("--crawler-match-file", help="File to be used by the crawler to chose what to download when scraping the client shared drives.", default=None)
-    parser.add_argument("--crawler-ignore-file", help="File to be used by the crawler to chose what folders to avoid when scraping the client shared drives.", default=None)
-    parser.add_argument("--no-replay", help="Disable replay recording", action="store_true")
-    parser.add_argument("--no-downgrade", help="Disables downgrading of unsupported extensions. This makes PyRDP harder to fingerprint but might impact the player's ability to replay captured traffic.", action="store_true")
-    parser.add_argument("--no-files", help="Do not extract files transferred between the client and server.", action="store_true")
+    config = configure()
+    reactor.listenTCP(config.listenPort, MITMServerFactory(config))
+    logger = logging.getLogger(LOGGER_NAMES.PYRDP)
 
-    args = parser.parse_args()
-    outDir = Path(args.output)
-    outDir.mkdir(exist_ok = True)
-
-    # Load configuration file
-    cfg = settings.load(settings.CONFIG_DIR + '/mitm.ini', DEFAULTS)
-
-    # Override some of the switches based on command line arguments.
-    if args.output:
-        cfg.set('vars', 'output_dir', args.output)
-    if args.log_filter:
-        cfg.set('logs', 'filter', args.log_filter)
-    if args.log_level:
-        cfg.set('vars', 'level', args.log_level)
-
-    # Configure the logging API
-    configureLoggers(cfg)
-    pyrdpLogger = logging.getLogger(LOGGER_NAMES.PYRDP)
-
-    targetHost, targetPort = parseTarget(args.target)
-    key, certificate = validateKeyAndCertificate(args.private_key, args.certificate)
-
-    listenPort = int(args.listen)
-
-
-    config = MITMConfig()
-    config.targetHost = targetHost
-    config.targetPort = targetPort
-    config.privateKeyFileName = key
-    config.certificateFileName = certificate
-    config.attackerHost = args.destination_ip
-    config.attackerPort = int(args.destination_port)
-    config.replacementUsername = args.username
-    config.replacementPassword = args.password
-    config.outDir = outDir
-    config.enableCrawler = args.crawl
-    config.crawlerMatchFileName = args.crawler_match_file
-    config.crawlerIgnoreFileName = args.crawler_ignore_file
-    config.recordReplays = not args.no_replay
-    config.downgrade = not args.no_downgrade
-    config.extractFiles = not args.no_files
-    config.disableActiveClipboardStealing = args.disable_active_clipboard
-
-
-    payload = None
-    powershell = None
-
-    if int(args.payload is not None) + int(args.payload_powershell is not None) + int(args.payload_powershell_file is not None) > 1:
-        pyrdpLogger.error("Only one of --payload, --payload-powershell and --payload-powershell-file may be supplied.")
-        sys.exit(1)
-
-    if args.payload is not None:
-        payload = args.payload
-        pyrdpLogger.info("Using payload: %(payload)s", {"payload": args.payload})
-    elif args.payload_powershell is not None:
-        powershell = args.payload_powershell
-        pyrdpLogger.info("Using powershell payload: %(payload)s", {"payload": args.payload_powershell})
-    elif args.payload_powershell_file is not None:
-        if not os.path.exists(args.payload_powershell_file):
-            pyrdpLogger.error("Powershell file %(path)s does not exist.", {"path": args.payload_powershell_file})
-            sys.exit(1)
-
-        try:
-            with open(args.payload_powershell_file, "r") as f:
-                powershell = f.read()
-        except IOError as e:
-            pyrdpLogger.error("Error when trying to read powershell file: %(error)s", {"error": e})
-            sys.exit(1)
-
-        pyrdpLogger.info("Using payload from powershell file: %(path)s", {"path": args.payload_powershell_file})
-
-    if powershell is not None:
-        payload = "powershell -EncodedCommand " + b64encode(powershell.encode("utf-16le")).decode()
-
-    if payload is not None:
-        if args.payload_delay is None:
-            pyrdpLogger.error("--payload-delay must be provided if a payload is provided.")
-            sys.exit(1)
-
-        if args.payload_duration is None:
-            pyrdpLogger.error("--payload-duration must be provided if a payload is provided.")
-            sys.exit(1)
-
-
-        try:
-            config.payloadDelay = int(args.payload_delay)
-        except ValueError:
-            pyrdpLogger.error("Invalid payload delay. Payload delay must be an integral number of milliseconds.")
-            sys.exit(1)
-
-        if config.payloadDelay < 0:
-            pyrdpLogger.error("Payload delay must not be negative.")
-            sys.exit(1)
-
-        if config.payloadDelay < 1000:
-            pyrdpLogger.warning("You have provided a payload delay of less than 1 second. We recommend you use a slightly longer delay to make sure it runs properly.")
-
-
-        try:
-            config.payloadDuration = int(args.payload_duration)
-        except ValueError:
-            pyrdpLogger.error("Invalid payload duration. Payload duration must be an integral number of milliseconds.")
-            sys.exit(1)
-
-        if config.payloadDuration < 0:
-            pyrdpLogger.error("Payload duration must not be negative.")
-            sys.exit(1)
-
-
-        config.payload = payload
-    elif args.payload_delay is not None:
-        pyrdpLogger.error("--payload-delay was provided but no payload was set.")
-        sys.exit(1)
-
-
-    logConfiguration(config)
-
-    reactor.listenTCP(listenPort, MITMServerFactory(config))
-    pyrdpLogger.info("MITM Server listening on port %(port)d", {"port": listenPort})
+    logger.info("MITM Server listening on port %(port)d", {"port": config.listenPort})
     reactor.run()
 
-    pyrdpLogger.info("MITM terminated")
-    logConfiguration(config)
+    logger.info("MITM terminated")
+    showConfiguration(config)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -6,15 +6,16 @@
 # Licensed under the GPLv3 or later.
 #
 
-
 # asyncio needs to be imported first to ensure that the reactor is
 # installed properly. Do not re-order.
 import asyncio
 from twisted.internet import asyncioreactor
 asyncioreactor.install(asyncio.get_event_loop())
 
+from pyrdp.core import settings
+from pyrdp.logging import LOGGER_NAMES, NotifyHandler, configure as configureLoggers
 from pyrdp.player import HAS_GUI
-from pyrdp.logging import LOGGER_NAMES, NotifyHandler
+from pyrdp.player.config import DEFAULTS
 
 from pathlib import Path
 import argparse
@@ -28,39 +29,18 @@ if HAS_GUI:
     from PySide2.QtWidgets import QApplication
 
 
-def prepareLoggers(logLevel: int, outDir: Path, headless: bool):
-    logDir = outDir / "logs"
-    logDir.mkdir(exist_ok = True)
+def enableNotifications(logger):
+    """Enable notifications if supported."""
+    # https://docs.python.org/3/library/os.html
+    if os.name != "nt":
+        notifyHandler = NotifyHandler()
+        notifyHandler.setFormatter(logging.Formatter("[{asctime}] - {message}", style = "{"))
 
-    textFormatter = logging.Formatter("[{asctime}] - {levelname} - {name} - {message}", style = "{")
-    notificationFormatter = logging.Formatter("[{asctime}] - {message}", style = "{")
+        uiLogger = logging.getLogger(LOGGER_NAMES.PLAYER_UI)
+        uiLogger.addHandler(notifyHandler)
+    else:
+        logger.warning("Notifications are not supported on this platform.")
 
-    streamHandler = logging.StreamHandler()
-    streamHandler.setFormatter(textFormatter)
-
-    fileHandler = logging.handlers.RotatingFileHandler(logDir / "player.log")
-    fileHandler.setFormatter(textFormatter)
-
-    pyrdpLogger = logging.getLogger(LOGGER_NAMES.PYRDP)
-    pyrdpLogger.addHandler(streamHandler)
-    pyrdpLogger.addHandler(fileHandler)
-    pyrdpLogger.setLevel(logLevel)
-
-    if not headless and HAS_GUI:
-        # https://docs.python.org/3/library/os.html
-        if os.name != "nt":
-            try:
-                notifyHandler = NotifyHandler()
-                notifyHandler.setFormatter(notificationFormatter)
-
-                uiLogger = logging.getLogger(LOGGER_NAMES.PLAYER_UI)
-                uiLogger.addHandler(notifyHandler)
-            except Exception:
-                # No notification daemon or DBus, can't use notifications.
-                pass
-        else:
-            pyrdpLogger.warning("Notifications are not supported for your platform, they will be disabled.")
-    return pyrdpLogger
 
 def main():
     """
@@ -72,15 +52,26 @@ def main():
     parser.add_argument("-b", "--bind", help="Bind address (default: 127.0.0.1)", default="127.0.0.1")
     parser.add_argument("-p", "--port", help="Bind port (default: 3000)", default=3000)
     parser.add_argument("-o", "--output", help="Output folder", default="pyrdp_output")
-    parser.add_argument("-L", "--log-level", help="Log level", default="INFO", choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"], nargs="?")
+    parser.add_argument("-L", "--log-level", help="Log level", default=None, choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"], nargs="?")
+    parser.add_argument("-F", "--log-filter", help="Only show logs from this logger name (accepts '*' wildcards)", default=None)
     parser.add_argument("--headless", help="Parse a replay without rendering the user interface.", action="store_true")
-
     args = parser.parse_args()
-    outDir = Path(args.output)
-    outDir.mkdir(exist_ok = True)
 
-    logLevel = getattr(logging, args.log_level)
-    logger = prepareLoggers(logLevel, outDir, args.headless)
+    cfg = settings.load(f'{settings.CONFIG_DIR}/player.ini', DEFAULTS)
+
+    # Modify configuration with switches.
+    if args.log_level:
+        cfg.set('vars', 'level', args.log_level)
+    if args.log_filter:
+        cfg.set('logs', 'filter', args.log_filter)
+    if args.output:
+        cfg.set('vars', 'output_dir', args.output)
+
+    configureLoggers(cfg)
+    logger = logging.getLogger(LOGGER_NAMES.PYRDP)
+
+    if cfg.getboolean('logs', 'notifications', fallback=False) and not args.headless:
+        enableNotifications(logger)
 
     if not HAS_GUI and not args.headless:
         logger.error('Headless mode is not specified and PySide2 is not installed. Install PySide2 to use the graphical user interface.')

--- a/pyrdp/core/settings.py
+++ b/pyrdp/core/settings.py
@@ -1,0 +1,33 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2020 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+from configparser import ConfigParser, ExtendedInterpolation
+
+import appdirs
+CONFIG_DIR = appdirs.user_config_dir("pyrdp", "pyrdp")
+
+
+def load(path: str, fallback: ConfigParser = None) -> ConfigParser:
+    """
+    Retrieve the PyRDP settings from a file
+
+    :param path: The path of the file to load.
+    :param fallback: The fallback configuration path.
+
+    :returns: A ConfigParser instance with the loaded settings.
+    :throws Exception: When the fallback configuration is missing and no configuration is found.
+    """
+    config = ConfigParser(interpolation=ExtendedInterpolation())
+    config.optionxform = str
+    try:
+        if len(config.read(path)) > 0:
+            return config
+    except Exception:
+        # Fallback to default settings.
+        pass
+
+    if not fallback:
+        raise Exception('Invalid configuration with no fallback specified')
+    return fallback

--- a/pyrdp/logging/__init__.py
+++ b/pyrdp/logging/__init__.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -8,5 +8,5 @@ from pyrdp.logging.adapters import SessionLogger
 from pyrdp.logging.filters import ConnectionMetadataFilter, LoggerNameFilter, SensorFilter
 from pyrdp.logging.formatters import JSONFormatter, VariableFormatter
 from pyrdp.logging.handlers import NotifyHandler
-from pyrdp.logging.log import getSSLLogger, LOGGER_NAMES, prepareSSLLogger
+from pyrdp.logging.log import getSSLLogger, LOGGER_NAMES, configure
 from pyrdp.logging.rc4 import RC4LoggingObserver

--- a/pyrdp/logging/log.py
+++ b/pyrdp/logging/log.py
@@ -1,13 +1,15 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 import logging
-from pathlib import Path
+import logging.config
+from configparser import ConfigParser
 
-from pyrdp.logging.formatters import SSLSecretFormatter
+from pathlib import Path
+from pyrdp.logging.filters import LoggerNameFilter
 
 
 class LOGGER_NAMES:
@@ -21,31 +23,13 @@ class LOGGER_NAMES:
     # Independent logger
     CRAWLER = "crawler"
 
+
 def getSSLLogger():
     """
     Get the SSL logger.
     """
     return logging.getLogger("ssl")
 
-def prepareSSLLogger(path: Path):
-    """
-    Prepares the SSL master secret logger.
-    Used to log TLS session secrets in a format expected by Wireshark.
-
-    :param path: path where master secrets will be saved.
-    """
-    formatter = SSLSecretFormatter()
-
-    fileHandler = logging.FileHandler(path)
-    fileHandler.setFormatter(formatter)
-
-    streamHandler = logging.StreamHandler()
-    streamHandler.setFormatter(formatter)
-
-    logger = getSSLLogger()
-    logger.addHandler(fileHandler)
-    logger.addHandler(streamHandler)
-    logger.setLevel(logging.INFO)
 
 def info(*args):
     logging.getLogger(LOGGER_NAMES.PYRDP).info(*args)
@@ -61,3 +45,92 @@ def warning(*args):
 
 def error(*args):
     logging.getLogger(LOGGER_NAMES.PYRDP).error(*args)
+
+
+def convertConfig(cfg: ConfigParser):
+    """
+    Transform a config file into a dictionary.
+
+    Keys with the title format `section:subsection:subsection` are
+    transformed into nested dictionaries
+
+    # Examples
+
+    ```ini
+    [toplevel]
+    a = 1
+    b = 2
+
+    [toplevel:sublevel]
+    c = 3
+    d = 4
+    ```
+
+    would convert to
+
+    ```python
+    'toplevel': {
+        'a': 1,
+        'b': 2,
+        'sublevel': {
+            'c': 3,
+            'd': 4,
+        }
+    }
+    ````
+    """
+    def get(d: dict, key: str, create=False) -> dict:
+        """Resolve a nested key in a dictionary."""
+        nested = key.split(':')
+        sub = None
+        for n in nested:
+            if sub is None:  # Top Level
+                if n not in d:
+                    if not create:
+                        return None
+                    d[n] = {}
+                sub = d[n]
+            else:
+                if n not in sub:
+                    if not create:
+                        return None
+                    sub[n] = {}
+                sub = sub[n]
+        return sub
+
+    out = {}
+    for s in cfg.sections():
+        sec = get(out, s, create=True)
+        for (k, v) in cfg.items(s):
+            sec[k] = v
+    return out
+
+
+def configure(config: ConfigParser) -> bool:
+    """Configure logging based on settings from disk."""
+    try:
+        cfg = convertConfig(config)
+        logs = cfg['logs']
+        logs['version'] = int(logs['version'])  # Needs to be integer.
+
+        for (k, v) in logs['loggers'].items():
+            v['handlers'] = [x.strip() for x in v['handlers'].split(',')]
+
+        # Ensure log directory exists.
+        logDir = Path(cfg['vars']['output_dir']) / cfg['vars']['log_dir']
+        logDir.mkdir(exist_ok = True)
+
+        logging.config.dictConfig(cfg['logs'])
+
+        # Enable the user configured filter.
+        if 'filter' in logs:
+            root = logging.getLogger(LOGGER_NAMES.PYRDP)
+            for h in root.handlers:
+                # Use type() because we want specific type, not a subclass.
+                if type(h) == logging.StreamHandler:
+                    h.filters.clear()
+                    h.addFilter(LoggerNameFilter(logs['filter']))
+        return True
+    except Exception as e:
+        logging.warning('Error Parsing PyRDP Configuraton - %s', e)
+        return False

--- a/pyrdp/mitm/__init__.py
+++ b/pyrdp/mitm/__init__.py
@@ -1,9 +1,9 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018, 2019 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 from pyrdp.mitm.cli import parseTarget, validateKeyAndCertificate
-from pyrdp.mitm.config import MITMConfig
+from pyrdp.mitm.config import MITMConfig, DEFAULTS
 from pyrdp.mitm.RDPMITM import RDPMITM

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -8,7 +8,6 @@
 File that contains methods related to the MITM command line.
 To be consumed either via bin/pyrdp-mitm.py or via twistd plugin.
 """
-import argparse
 import logging
 import logging.handlers
 import os
@@ -16,11 +15,11 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
-import appdirs
 import OpenSSL
 
 from pyrdp.core.ssl import ServerTLSContext
-from pyrdp.logging import JSONFormatter, log, LOGGER_NAMES, LoggerNameFilter, SessionLogger, VariableFormatter
+from pyrdp.core.settings import CONFIG_DIR
+from pyrdp.logging import JSONFormatter, log, LOGGER_NAMES, LoggerNameFilter, VariableFormatter
 from pyrdp.mitm.config import MITMConfig
 
 
@@ -91,13 +90,12 @@ def getSSLPaths() -> (str, str):
     Get the path to the TLS key and certificate in pyrdp's config directory.
     :return: the path to the key and the path to the certificate.
     """
-    config = appdirs.user_config_dir("pyrdp", "pyrdp")
 
-    if not os.path.exists(config):
-        os.makedirs(config)
+    if not os.path.exists(CONFIG_DIR):
+        os.makedirs(CONFIG_DIR)
 
-    key = config + "/private_key.pem"
-    certificate = config + "/certificate.pem"
+    key = CONFIG_DIR + "/private_key.pem"
+    certificate = CONFIG_DIR + "/certificate.pem"
     return key, certificate
 
 
@@ -116,61 +114,6 @@ def generateCertificate(keyPath: str, certificatePath: str) -> bool:
 
     result = os.system("openssl req -newkey rsa:2048 -nodes -keyout %s -x509 -days 365 -out %s -subj \"/CN=www.example.com/O=PYRDP/C=US\" 2>%s" % (keyPath, certificatePath, nullDevicePath))
     return result == 0
-
-
-def prepareLoggers(logLevel: int, logFilter: str, sensorID: str, outDir: Path):
-    """
-    :param logLevel: log level for the stream handler.
-    :param logFilter: logger name to filter on.
-    :param sensorID: ID to differentiate between instances of this program in the JSON log.
-    :param outDir: output directory.
-    """
-    logDir = outDir / "logs"
-    logDir.mkdir(exist_ok = True)
-
-    formatter = VariableFormatter("[{asctime}] - {levelname} - {sessionID} - {name} - {message}", style = "{", defaultVariables = {
-        "sessionID": "GLOBAL"
-    })
-
-    streamHandler = logging.StreamHandler()
-    streamHandler.setFormatter(formatter)
-    streamHandler.setLevel(logLevel)
-    streamHandler.addFilter(LoggerNameFilter(logFilter))
-
-    logFileHandler = logging.handlers.TimedRotatingFileHandler(logDir / "mitm.log", when = "D")
-    logFileHandler.setFormatter(formatter)
-
-    jsonFileHandler = logging.FileHandler(logDir / "mitm.json")
-    jsonFileHandler.setFormatter(JSONFormatter({"sensor": sensorID}))
-    jsonFileHandler.setLevel(logging.INFO)
-
-    rootLogger = logging.getLogger(LOGGER_NAMES.PYRDP)
-    rootLogger.addHandler(streamHandler)
-    rootLogger.addHandler(logFileHandler)
-    rootLogger.setLevel(logging.DEBUG)
-
-    connectionsLogger = logging.getLogger(LOGGER_NAMES.MITM_CONNECTIONS)
-    connectionsLogger.addHandler(jsonFileHandler)
-
-    crawlerFormatter = VariableFormatter("[{asctime}] - {sessionID} - {message}", style = "{", defaultVariables = {
-        "sessionID": "GLOBAL"
-    })
-
-    crawlerFileHandler = logging.FileHandler(logDir / "crawl.log")
-    crawlerFileHandler.setFormatter(crawlerFormatter)
-
-    jsonCrawlerFileHandler = logging.FileHandler(logDir / "crawl.json")
-    jsonCrawlerFileHandler.setFormatter(JSONFormatter({"sensor": sensorID}))
-
-    crawlerLogger = logging.getLogger(LOGGER_NAMES.CRAWLER)
-    crawlerLogger.addHandler(crawlerFileHandler)
-    crawlerLogger.addHandler(jsonCrawlerFileHandler)
-    crawlerLogger.setLevel(logging.INFO)
-
-    log.prepareSSLLogger(logDir / "ssl.log")
-
-    return logging.getLogger(LOGGER_NAMES.MITM)
-
 
 def logConfiguration(config: MITMConfig):
     logging.getLogger(LOGGER_NAMES.MITM).info("Target: %(target)s:%(port)d", {"target": config.targetHost, "port": config.targetPort})

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -8,19 +8,21 @@
 File that contains methods related to the MITM command line.
 To be consumed either via bin/pyrdp-mitm.py or via twistd plugin.
 """
+import argparse
 import logging
 import logging.handlers
 import os
 import sys
-from pathlib import Path
 from typing import Tuple
+from pathlib import Path
+from base64 import b64encode
 
 import OpenSSL
 
 from pyrdp.core.ssl import ServerTLSContext
-from pyrdp.core.settings import CONFIG_DIR
-from pyrdp.logging import JSONFormatter, log, LOGGER_NAMES, LoggerNameFilter, VariableFormatter
-from pyrdp.mitm.config import MITMConfig
+from pyrdp.core import settings
+from pyrdp.logging import LOGGER_NAMES, configure as configureLoggers
+from pyrdp.mitm.config import MITMConfig, DEFAULTS
 
 
 def parseTarget(target: str) -> Tuple[str, int]:
@@ -91,11 +93,11 @@ def getSSLPaths() -> (str, str):
     :return: the path to the key and the path to the certificate.
     """
 
-    if not os.path.exists(CONFIG_DIR):
-        os.makedirs(CONFIG_DIR)
+    if not os.path.exists(settings.CONFIG_DIR):
+        os.makedirs(settings.CONFIG_DIR)
 
-    key = CONFIG_DIR + "/private_key.pem"
-    certificate = CONFIG_DIR + "/certificate.pem"
+    key = settings.CONFIG_DIR + "/private_key.pem"
+    certificate = settings.CONFIG_DIR + "/certificate.pem"
     return key, certificate
 
 
@@ -115,6 +117,155 @@ def generateCertificate(keyPath: str, certificatePath: str) -> bool:
     result = os.system("openssl req -newkey rsa:2048 -nodes -keyout %s -x509 -days 365 -out %s -subj \"/CN=www.example.com/O=PYRDP/C=US\" 2>%s" % (keyPath, certificatePath, nullDevicePath))
     return result == 0
 
-def logConfiguration(config: MITMConfig):
+
+def showConfiguration(config: MITMConfig):
     logging.getLogger(LOGGER_NAMES.MITM).info("Target: %(target)s:%(port)d", {"target": config.targetHost, "port": config.targetPort})
     logging.getLogger(LOGGER_NAMES.MITM).info("Output directory: %(outputDirectory)s", {"outputDirectory": config.outDir.absolute()})
+
+
+def buildArgParser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target", help="IP:port of the target RDP machine (ex: 192.168.1.10:3390)")
+    parser.add_argument("-l", "--listen", help="Port number to listen on (default: 3389)", default=3389)
+    parser.add_argument("-o", "--output", help="Output folder", default="pyrdp_output")
+    parser.add_argument("-i", "--destination-ip", help="Destination IP address of the PyRDP player.If not specified, RDP events are not sent over the network.")
+    parser.add_argument("-d", "--destination-port", help="Listening port of the PyRDP player (default: 3000).", default=3000)
+    parser.add_argument("-k", "--private-key", help="Path to private key (for SSL)")
+    parser.add_argument("-c", "--certificate", help="Path to certificate (for SSL)")
+    parser.add_argument("-u", "--username", help="Username that will replace the client's username", default=None)
+    parser.add_argument("-p", "--password", help="Password that will replace the client's password", default=None)
+    parser.add_argument("-L", "--log-level", help="Console logging level. Logs saved to file are always verbose.", default="INFO", choices=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"])
+    parser.add_argument("-F", "--log-filter", help="Only show logs from this logger name (accepts '*' wildcards)", default="")
+    parser.add_argument("-s", "--sensor-id", help="Sensor ID (to differentiate multiple instances of the MITM where logs are aggregated at one place)", default="PyRDP")
+    parser.add_argument("--payload", help="Command to run automatically upon connection", default=None)
+    parser.add_argument("--payload-powershell", help="PowerShell command to run automatically upon connection", default=None)
+    parser.add_argument("--payload-powershell-file", help="PowerShell script to run automatically upon connection (as -EncodedCommand)", default=None)
+    parser.add_argument("--payload-delay", help="Time to wait after a new connection before sending the payload, in milliseconds", default=None)
+    parser.add_argument("--payload-duration", help="Amount of time for which input / output should be dropped, in milliseconds. This can be used to hide the payload screen.", default=None)
+    parser.add_argument("--disable-active-clipboard", help="Disables the active clipboard stealing to request clipboard content upon connection.", action="store_true")
+    parser.add_argument("--crawl", help="Enable automatic shared drive scraping", action="store_true")
+    parser.add_argument("--crawler-match-file", help="File to be used by the crawler to chose what to download when scraping the client shared drives.", default=None)
+    parser.add_argument("--crawler-ignore-file", help="File to be used by the crawler to chose what folders to avoid when scraping the client shared drives.", default=None)
+    parser.add_argument("--no-replay", help="Disable replay recording", action="store_true")
+    parser.add_argument("--no-downgrade", help="Disables downgrading of unsupported extensions. This makes PyRDP harder to fingerprint but might impact the player's ability to replay captured traffic.", action="store_true")
+    parser.add_argument("--no-files", help="Do not extract files transferred between the client and server.", action="store_true")
+
+    return parser
+
+
+def configure(cmdline=None) -> MITMConfig:
+    parser = buildArgParser()
+
+    if cmdline:
+        args = parser.parse_args(cmdline)
+    else:
+        args = parser.parse_args()
+
+    # Load configuration file.
+    cfg = settings.load(settings.CONFIG_DIR + '/mitm.ini', DEFAULTS)
+
+    # Override some of the switches based on command line arguments.
+    if args.output:
+        cfg.set('vars', 'output_dir', args.output)
+    if args.log_filter:
+        cfg.set('logs', 'filter', args.log_filter)
+    if args.log_level:
+        cfg.set('vars', 'level', args.log_level)
+
+    configureLoggers(cfg)
+    logger = logging.getLogger(LOGGER_NAMES.PYRDP)
+
+    outDir = Path(cfg.get('vars', 'output_dir'))
+    outDir.mkdir(exist_ok=True)
+
+    targetHost, targetPort = parseTarget(args.target)
+    key, certificate = validateKeyAndCertificate(args.private_key, args.certificate)
+
+    config = MITMConfig()
+    config.targetHost = targetHost
+    config.targetPort = targetPort
+    config.privateKeyFileName = key
+    config.listenPort = int(args.listen)
+    config.certificateFileName = certificate
+    config.attackerHost = args.destination_ip
+    config.attackerPort = int(args.destination_port)
+    config.replacementUsername = args.username
+    config.replacementPassword = args.password
+    config.outDir = outDir
+    config.enableCrawler = args.crawl
+    config.crawlerMatchFileName = args.crawler_match_file
+    config.crawlerIgnoreFileName = args.crawler_ignore_file
+    config.recordReplays = not args.no_replay
+    config.downgrade = not args.no_downgrade
+    config.extractFiles = not args.no_files
+    config.disableActiveClipboardStealing = args.disable_active_clipboard
+
+    payload = None
+    powershell = None
+
+    if int(args.payload is not None) + int(args.payload_powershell is not None) + int(args.payload_powershell_file is not None) > 1:
+        logger.error("Only one of --payload, --payload-powershell and --payload-powershell-file may be supplied.")
+        sys.exit(1)
+
+    if args.payload is not None:
+        payload = args.payload
+        logger.info("Using payload: %(payload)s", {"payload": args.payload})
+    elif args.payload_powershell is not None:
+        powershell = args.payload_powershell
+        logger.info("Using powershell payload: %(payload)s", {"payload": args.payload_powershell})
+    elif args.payload_powershell_file is not None:
+        if not os.path.exists(args.payload_powershell_file):
+            logger.error("Powershell file %(path)s does not exist.", {"path": args.payload_powershell_file})
+            sys.exit(1)
+
+        try:
+            with open(args.payload_powershell_file, "r") as f:
+                powershell = f.read()
+        except IOError as e:
+            logger.error("Error when trying to read powershell file: %(error)s", {"error": e})
+            sys.exit(1)
+
+        logger.info("Using payload from powershell file: %(path)s", {"path": args.payload_powershell_file})
+
+    if powershell is not None:
+        payload = "powershell -EncodedCommand " + b64encode(powershell.encode("utf-16le")).decode()
+
+    if payload is not None:
+        if args.payload_delay is None:
+            logger.error("--payload-delay must be provided if a payload is provided.")
+            sys.exit(1)
+
+        if args.payload_duration is None:
+            logger.error("--payload-duration must be provided if a payload is provided.")
+            sys.exit(1)
+
+        try:
+            config.payloadDelay = int(args.payload_delay)
+        except ValueError:
+            logger.error("Invalid payload delay. Payload delay must be an integral number of milliseconds.")
+            sys.exit(1)
+
+        if config.payloadDelay < 0:
+            logger.error("Payload delay must not be negative.")
+            sys.exit(1)
+
+        if config.payloadDelay < 1000:
+            logger.warning("You have provided a payload delay of less than 1 second. We recommend you use a slightly longer delay to make sure it runs properly.")
+
+        try:
+            config.payloadDuration = int(args.payload_duration)
+        except ValueError:
+            logger.error("Invalid payload duration. Payload duration must be an integral number of milliseconds.")
+            sys.exit(1)
+
+        if config.payloadDuration < 0:
+            logger.error("Payload duration must not be negative.")
+            sys.exit(1)
+
+        config.payload = payload
+    elif args.payload_delay is not None:
+        logger.error("--payload-delay was provided but no payload was set.")
+        sys.exit(1)
+
+    showConfiguration(config)
+    return config

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -6,6 +6,7 @@
 
 from pathlib import Path
 from typing import Optional
+from pyrdp.core import settings
 
 
 class MITMConfig:
@@ -84,3 +85,8 @@ class MITMConfig:
         Get the directory for intercepted files.
         """
         return self.outDir / "files"
+
+"""
+The default MITM configuration.
+"""
+DEFAULTS =  settings.load(Path(__file__).parent.absolute() / "mitm.default.ini")

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -21,6 +21,9 @@ class MITMConfig:
         self.targetPort: int = None
         """The RDP server's port"""
 
+        self.listenPort: int = 3389
+        """The port to bind for listening."""
+
         self.certificateFileName: str = None
         """Path to the TLS certificate"""
 

--- a/pyrdp/mitm/mitm.default.ini
+++ b/pyrdp/mitm/mitm.default.ini
@@ -1,0 +1,193 @@
+# This is the default PyRDP MITM configuration file.
+# It should not be modified directly. Instead, copy the
+# file to the system's user configuration directory
+# to override the defaults.
+#
+# Configuration specified on the command line has
+# precedence over configuration files.
+#
+# On most Linux distributions, this file should be in
+#
+#     $HOME/.config/pyrdp/mitm.ini
+#
+# On Windows systems, the file should be in:
+#
+#     %APPDATA%/pyrdp/mitm.ini
+# 
+# On MacOS:
+#
+#     ~/Library/Application Support/pyrdp/mitm.ini
+#
+# Subsections are delimited by the `:` character to avoid ambiguity with
+# logger names (e.g. `pyrdp.player.ui`)
+
+# This section defines global variables. Variables can be referenced
+# by using the `$(vars:varname)` syntax.
+#
+# It should be possible to change all interesting aspects of the
+# configuration through this section
+#
+[vars]
+# The name of the sensor. This is used to disambiguate when multiple
+# instances of PyRDP are running on the same server
+sensor_id = PyRDP
+
+# The directory to output logs to.
+# This is a relative directory to the output directory
+log_dir = logs
+
+# The output directory where PyRDP will store various artifacts.
+#
+# This configures the base directory that PyRDP will use.
+# It can be relative to the working directory from where PyRDP was
+# started or an absolute path.
+output_dir = pyrdp_output
+
+# The default logging level.
+level = INFO
+
+# The default log format.
+log_format_default = [{asctime}] - {levelname} - {sessionID} - {name} - {message}
+
+# The log format where compact output is used.
+log_format_compact = [{asctime}] - {sessionID} - {message}
+
+# -----------------------------------------------------------------
+# The next section configures the PyRDP logging facilities.
+#
+# This uses the logging.config.dictConfig format and nested keys
+# (`[handlers:stderr]`) should be in separate sections due to INI
+# limitations.
+# -----------------------------------------------------------------
+
+# The settings below are the PyRDP defaults.
+[logs]
+# dictConfig version. Do not modify.
+version = 1
+# A partial logger name to restrict console output to.
+# wildcards are supported. This is overridden by the `-F` flag if
+# present and does not affect file logging.
+filter = pyrdp
+
+# -----------------------------------------------------------------
+# Loggers and Verbosity Levels
+#
+# To disable a logger, simply remove its `level = ...` line.
+# Severity can be one of DEBUG, INFO, WARNING, ERROR or CRITICAL
+# Levels can be customized per handler and logger.
+# Note that PyRDP's `-L` switch affects the root logger.
+# -----------------------------------------------------------------
+# Root level logger for PyRDP.
+[logs:loggers:pyrdp]
+handlers = console, mitm
+# Output only to console.
+# handlers = console
+level = ${vars:level}
+
+# Connection Logging
+[logs:loggers:pyrdp.mitm.connections]
+handlers = connections
+level    = ${vars:level}
+
+# Crawler Logging
+[logs:loggers:crawler]
+handlers = crawl_json, crawl_txt
+level    = ${vars:level}
+
+# SSL Secret Logging
+[logs:loggers:ssl]
+handlers = ssl, ssl_console
+# Always log SSL master secrets.
+level    = DEBUG
+
+
+# -----------------------------------------------------------------
+# WARNING:
+#
+# Do not edit the sections below unless you are sure of what you
+# are doing.  Some of the settings here are required for PyRDP to
+# function properly and everything that users might want to
+# modify is exposed as variables or in the sections above.
+# -----------------------------------------------------------------
+
+# -----------------------------------------------------------------
+# Handlers
+# -----------------------------------------------------------------
+# Outputs to stderr
+[logs:handlers:console]
+class     = logging.StreamHandler
+formatter = default
+stream    = ext://sys.stderr
+# filters   = []
+
+# Outputs to mitm.log
+[logs:handlers:mitm]
+class     = logging.handlers.TimedRotatingFileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/mitm.log
+when      = D
+formatter = default
+
+# Outputs connections to mitm.json
+[logs:handlers:connections]
+class     = logging.FileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/mitm.json
+formatter = json
+
+
+# Outputs to crawl.log
+[logs:handlers:crawl_txt]
+class     = logging.FileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/crawl.log
+formatter = compact
+
+# Outputs to crawl.json
+[logs:handlers:crawl_json]
+class     = logging.FileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/crawl.json
+formatter = json
+
+# Outputs SSL secrets
+[logs:handlers:ssl]
+class     = logging.FileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/ssl.log
+formatter = ssl
+
+[logs:handlers:ssl_console]
+class     = logging.StreamHandler
+stream    = ext://sys.stderr
+formatter = ssl
+
+# -----------------------------------------------------------------
+# Formatters
+# -----------------------------------------------------------------
+# Textual / Default Format
+[logs:formatters:default]
+() = pyrdp.logging.formatters.VariableFormatter
+fmt = ${vars:log_format_default}
+style = {
+
+# JSON Format
+[logs:formatters:json]
+() = pyrdp.logging.formatters.JSONFormatter
+
+[logs:formatters:json:baseDict]
+sensor = ${vars:sensor_id}
+
+# Compact logs
+[logs:formatters:compact]
+() = pyrdp.logging.formatters.VariableFormatter
+fmt = ${vars:log_format_compact}
+style = {
+
+
+# Identifier for logs not tied to a specific session.
+# This is used for log entries.
+[logs:formatters:default:defaultVariables]
+sessionID = GLOBAL
+
+[logs:formatters:compact:defaultVariables]
+sessionID = GLOBAL
+
+# Raw SSL Secret formatting for dumping secrets
+[logs:formatters:ssl]
+() = pyrdp.logging.formatters.SSLSecretFormatter

--- a/pyrdp/player/config.py
+++ b/pyrdp/player/config.py
@@ -1,0 +1,15 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2020 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from pyrdp.core import settings
+
+from pathlib import Path
+
+
+"""
+The default configuration for the Player.
+"""
+DEFAULTS =  settings.load(Path(__file__).parent.absolute() / "player.default.ini")

--- a/pyrdp/player/player.default.ini
+++ b/pyrdp/player/player.default.ini
@@ -1,0 +1,102 @@
+# This is the default PyRDP Player configuration file.
+# It should not be modified directly. Instead, copy the
+# file to the system's user configuration directory
+# to override the defaults.
+#
+# Configuration specified on the command line has
+# precedence over configuration files.
+#
+# On most Linux distributions, this file should be in
+#
+#     $HOME/.config/pyrdp/player.ini
+#
+# On Windows systems, the file should be in:
+#
+#     %APPDATA%/pyrdp/player.ini
+# 
+# On MacOS:
+#
+#     ~/Library/Application Support/pyrdp/player.ini
+#
+# Subsections are delimited by the `:` character to avoid ambiguity with
+# logger names (e.g. `pyrdp.player.ui`)
+
+# This section defines global variables. Variables can be referenced
+# by using the `$(vars:varname)` syntax.
+#
+# It should be possible to change all interesting aspects of the
+# configuration through this section
+#
+[vars]
+# The output directory where PyRDP will store various artifacts.
+#
+# This configures the base directory that PyRDP will use.
+# It can be relative to the working directory from where PyRDP was
+# started or an absolute path.
+output_dir = pyrdp_output
+
+# The directory to output logs to.
+# This is a relative directory to the output directory
+log_dir = logs
+
+# Default log level.
+level      = INFO
+
+# The default log format.
+log_format_default = [{asctime}] - {levelname} - {name} - {message}
+
+# -----------------------------------------------------------------
+# The next section configures the PyRDP logging facilities.
+#
+# This uses the logging.config.dictConfig format and nested keys
+# (`[handlers:stderr]`) should be in separate sections due to INI
+# limitations.
+# -----------------------------------------------------------------
+
+[logs]
+# Do not modify.
+version = 1
+
+# Filter logs to this logger.
+# Accepts wildcards: `pyrdp.ui.*`
+filter = pyrdp
+
+# Enable notifications.
+# This requires a supported operating system with DBus and a
+# notification daemon.
+notifications = True
+
+# -----------------------------------------------------------------
+# Loggers and Verbosity Levels
+#
+# To disable a logger, simply remove its `level = ...` line.
+# Severity can be one of DEBUG, INFO, WARNING, ERROR or CRITICAL
+# Levels can be customized per handler and logger.
+# Note that PyRDP's `-L` switch affects the root logger.
+# -----------------------------------------------------------------
+[logs:loggers:pyrdp]
+handlers = console, player
+level = ${vars:level}
+
+# -----------------------------------------------------------------
+# WARNING:
+#
+# Do not edit the sections below unless you are sure of what you
+# are doing.  Some of the settings here are required for PyRDP to
+# function properly and everything that users might want to
+# modify is exposed as variables or in the sections above.
+# -----------------------------------------------------------------
+[logs:handlers:console]
+class     = logging.StreamHandler
+formatter = default
+stream    = ext://sys.stderr
+
+[logs:handlers:player]
+class     = logging.handlers.RotatingFileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/player.log
+formatter = default
+
+[logs:formatters:default]
+class: logging.Formatter
+format = ${vars:log_format_default}
+style = {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ setup(name='pyrdp',
     author_email='egg997@gmail.com, flabelle@gosecure.ca',
     url='https://github.com/GoSecure/pyrdp',
     packages=setuptools.find_packages(include=["pyrdp", "pyrdp.*"]),
-    package_data={"pyrdp": ["mitm/crawler_config/*.txt"]},
+    package_data={
+        "pyrdp": ["mitm/crawler_config/*.txt"],
+        "": ["*.default.ini"]
+    },
     ext_modules=[Extension('rle', ['ext/rle.c'])],
     scripts=[
         'bin/pyrdp-clonecert.py',


### PR DESCRIPTION
This exposes all logging configuration (and eventually command line flags) through a configuration file.

The idea is to give users more control on what is output and eventually simplify launching the tool.
The PR is a draft because I want to clean up the existing logging code and add support for the player before merging.

The plan is to have a `mitm.ini` and `player.ini` which contains all configuration parameters for PyRDP. We could also theoretically have a single `config.ini` which all tools read, but that would increase log configuration complexity.