### PR TITLE
Add support for transparent proxying on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PyRDP was [introduced in 2018](https://www.gosecure.net/blog/2018/12/19/rdp-man-
       - [Choosing when to resume normal activity](#choosing-when-to-resume-normal-activity)
     + [Other MITM arguments](#other-mitm-arguments)
       - [--no-downgrade](#--no-downgrade)
+      - [--transparent](#--transparent)
   * [Using the PyRDP Player](#using-the-pyrdp-player)
     + [Playing a replay file](#playing-a-replay-file)
     + [Listening for live connections](#listening-for-live-connections)
@@ -331,6 +332,60 @@ to be established. The following are currently not affected by this switch and w
 **NOTE**: If being able to eventually replay the full session is important, a good solution is to record the raw 
 RDP traffic using Wireshark and keep the TLS master secrets. Whenever PyRDP adds support for additional extensions, 
 it would then become possible to extract a valid RDP replay file from the raw network capture.
+
+##### `--transparent`
+
+Tells PyRDP to attempt to spoof the source IP address of the client so that the server sees the real IP
+address instead of the MITM one.  This option is only useful in certain scenarios where the MITM is physically
+a gateway between clients and the server and sees all traffic. It requires root privileges, only works on
+Linux and requires manual firewall configuration to ensure that traffic is router properly. The following is
+an example configuration:
+
+```
+# Additional configuration required on the MITM (example)
+#  +--------+           +------+             +--------+
+#  | CLIENT | <-- 1 --> | MITM | <--- 2 ---> | SERVER |
+#  +--------+           +------+             +--------+
+#   10.6.6.6            10.1.1.1              10.2.2.2
+
+# The IP of the RDP server which will receive proxied connections.
+SERVER_IP=10.2.2.2
+
+# The mark number to use in iptables (should be fine as-is)
+MARK=1
+
+# The routing table ID for custom rules (should be fine as-is)
+TABLE_ID=100
+
+# Create a custom routing table for pyrdp traffic
+echo "$TABLE_ID    pyrdp" >> /etc/iproute2/rt_tables
+
+# Route RDP traffic intended for the target server to local PyRDP (1)
+iptables -t nat \
+    -A PREROUTING \
+    -d $SERVER_IP \
+    -p tcp -m tcp --dport 3389 \
+    -j REDIRECT --to-port 3389
+
+# Mark RDP traffic intended for clients (2)
+iptables -t mangle -A PREROUTING \
+    -s $SERVER_IP \
+    -m tcp -p tcp --sport 3389 \
+    -j MARK --set-mark $MARK
+
+# Set route lookup to the pyrdp table for marked packets.
+ip rule add fwmark $MARK lookup $TABLE_ID
+
+# Add a custom route that redirects traffic intended for the outside world to loopback
+# So that server-client traffic passes through PyRDP
+# This table will only ever be used by RDP so it should not be problematic
+ip route add local dev lo table $TABLE_ID
+```
+
+This setup is a base example and might be much more complex depending on your environment and constraints.
+To cleanup, you should delete the created routes, remove the custom routing table from `rt_tables` and
+remove the `ip rule`.
+
 
 ### Using the PyRDP Player
 Use `pyrdp-player.py` to run the player.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ a gateway between clients and the server and sees all traffic. It requires root 
 Linux and requires manual firewall configuration to ensure that traffic is router properly. The following is
 an example configuration:
 
-```
+```bash
 # Additional configuration required on the MITM (example)
 #  +--------+           +------+             +--------+
 #  | CLIENT | <-- 1 --> | MITM | <--- 2 ---> | SERVER |

--- a/pyrdp/core/__init__.py
+++ b/pyrdp/core/__init__.py
@@ -15,4 +15,4 @@ from pyrdp.core.sequencer import AsyncIOSequencer, Sequencer
 from pyrdp.core.stream import ByteStream, StrictStream
 from pyrdp.core.subject import ObservedBy, Subject
 from pyrdp.core.timer import Timer
-from pyrdp.core.twisted import AwaitableClientFactory
+from pyrdp.core.twisted import AwaitableClientFactory, connectTransparent

--- a/pyrdp/core/twisted.py
+++ b/pyrdp/core/twisted.py
@@ -10,7 +10,7 @@ import socket
 import logging
 
 from twisted.internet.protocol import ClientFactory, Protocol
-from twisted.internet import tcp, fdesc
+from twisted.internet import tcp, fdesc, reactor
 
 LOG = logging.getLogger(__name__)
 
@@ -65,7 +65,6 @@ class TransparentConnector(tcp.Connector):
 
 
 def connectTransparent(host, port, factory, timeout=30, bindAddress=None):
-    from twisted.internet import reactor
     """Create a transparent proxy connection managed by Twisted."""
     c = TransparentConnector(host, port, factory, timeout, bindAddress, reactor)
     c.connect()

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -149,6 +149,7 @@ def buildArgParser():
     parser.add_argument("--no-replay", help="Disable replay recording", action="store_true")
     parser.add_argument("--no-downgrade", help="Disables downgrading of unsupported extensions. This makes PyRDP harder to fingerprint but might impact the player's ability to replay captured traffic.", action="store_true")
     parser.add_argument("--no-files", help="Do not extract files transferred between the client and server.", action="store_true")
+    parser.add_argument("--transparent", help="Spoof source IP for connections to the server (See README)", action="store_true")
 
     return parser
 
@@ -197,6 +198,7 @@ def configure(cmdline=None) -> MITMConfig:
     config.crawlerIgnoreFileName = args.crawler_ignore_file
     config.recordReplays = not args.no_replay
     config.downgrade = not args.no_downgrade
+    config.transparent = args.transparent
     config.extractFiles = not args.no_files
     config.disableActiveClipboardStealing = args.disable_active_clipboard
 


### PR DESCRIPTION
This feature adds the ability to tell PyRDP to perform a transparent connection to the server by using the source IP of the client. This cannot be fully supported by PyRDP and relies on firewall configuration to properly route traffic.

The PR adds documentation of an example scenario and configuration, along with the required PyRDP code to create a transparent socket.