### PR TITLE
Dockerfile improvements again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Docker image
       run: docker build .
+    - name: Build slim Docker image
+      run: docker build -f Dockerfile.slim .
 
   install-and-test-ubuntu:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # Handles compiling and package installation
 FROM ubuntu:18.04 AS compile-image
-# Install Dependencies
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip \
         # Required for local pip install
         python3-setuptools \
         # Required for venv setup
         python3-venv \
-        # Required to build RLE module
-        build-essential python3-dev
+        # Required to build RLE module and dbus-python
+        build-essential python3-dev \
+        libdbus-1-dev \
+        libdbus-glib-1-dev
 
 RUN python3 -m venv /opt/venv
 # Make sure we use the virtualenv:
@@ -21,14 +23,18 @@ COPY ext/rle.c /pyrdp/ext/rle.c
 COPY pyrdp/ /pyrdp/pyrdp/
 # Install in the virtualenv
 RUN cd /pyrdp \
-    && pip3 --no-cache-dir install . -U
+    && pip3 --no-cache-dir install .[GUI] -U
+
 
 # Handles runtime only (minimize size for distribution)
 FROM ubuntu:18.04 AS docker-image
 
-# Install Dependencies
+# Install runtime dependencies except pre-built venv
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
-    && rm -rf /var/lib/apt/lists/*
+        # GUI and notifications stuff
+        libgl1-mesa-glx \
+        notify-osd dbus-x11 libxkbcommon-x11-0 \
+        && rm -rf /var/lib/apt/lists/*
 
 # Copy preinstalled dependencies from compile image
 COPY --from=compile-image /opt/venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,44 @@
-FROM ubuntu:18.04
-
+# Handles compiling and package installation
+FROM ubuntu:18.04 AS compile-image
 # Install Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip \
         # Required for local pip install
         python3-setuptools \
-        # Required to build dbus-python
-        build-essential python3-dev \
-        libdbus-1-dev \
-        libdbus-glib-1-dev \
-        libgl1-mesa-glx \
-        notify-osd dbus-x11 \
+        # Required for venv setup
+        python3-venv \
+        # Required to build RLE module
+        build-essential python3-dev
+
+RUN python3 -m venv /opt/venv
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy only what is required for the install
+COPY setup.py /pyrdp/setup.py
+COPY bin/ /pyrdp/bin/
+COPY ext/rle.c /pyrdp/ext/rle.c
+COPY pyrdp/ /pyrdp/pyrdp/
+# Install in the virtualenv
+RUN cd /pyrdp \
+    && pip3 --no-cache-dir install . -U
+
+# Handles runtime only (minimize size for distribution)
+FROM ubuntu:18.04 AS docker-image
+
+# Install Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /pyrdp
-
-RUN cd /pyrdp \
-    && pip3 --no-cache-dir install -e . -U
+# Copy preinstalled dependencies from compile image
+COPY --from=compile-image /opt/venv /opt/venv
 
 # Create user
-RUN useradd --create-home --home-dir /home/pyrdp pyrdp 
+RUN useradd --create-home --home-dir /home/pyrdp pyrdp
 USER pyrdp
 
+# UTF-8 support on the console output (for pyrdp-player)
+ENV PYTHONIOENCODING=utf-8
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /home/pyrdp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-setuptools \
         # Required for venv setup
         python3-venv \
-        # Required to build RLE module and dbus-python
+        # Required to build RLE module and dbus-python (GUI)
         build-essential python3-dev \
         libdbus-1-dev \
         libdbus-glib-1-dev
@@ -23,7 +23,7 @@ COPY ext/rle.c /pyrdp/ext/rle.c
 COPY pyrdp/ /pyrdp/pyrdp/
 # Install in the virtualenv
 RUN cd /pyrdp \
-    && pip3 --no-cache-dir install .[GUI] -U
+    && pip3 --no-cache-dir install .[full] -U
 
 
 # Handles runtime only (minimize size for distribution)

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -1,25 +1,50 @@
-FROM ubuntu:18.04
-
+# Handles compiling and package installation
+FROM ubuntu:18.04 AS compile-image
 # Install Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip \
         # Required for local pip install
         python3-setuptools \
-        # Required to build dbus-python
+        # Required for venv setup
+        python3-venv \
+        # Required to build RLE module and dbus-python
         build-essential python3-dev \
         libdbus-1-dev \
-        libdbus-glib-1-dev \
-        libgl1-mesa-glx \
-        notify-osd dbus-x11 \
-    && rm -rf /var/lib/apt/lists/*
+        libdbus-glib-1-dev
 
-COPY . /pyrdp
+RUN python3 -m venv /opt/venv
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
 
+# Copy only what is required for the install
+COPY setup.py /pyrdp/setup.py
+COPY bin/ /pyrdp/bin/
+COPY ext/rle.c /pyrdp/ext/rle.c
+COPY pyrdp/ /pyrdp/pyrdp/
+# Install in the virtualenv
 RUN cd /pyrdp \
-    && pip3 --no-cache-dir install -e . -U
+    && pip3 --no-cache-dir install .[GUI] -U
+
+
+# Handles runtime only (minimize size for distribution)
+FROM ubuntu:18.04 AS docker-image
+
+# Install Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+        # GUI stuff
+        libgl1-mesa-glx \
+        notify-osd dbus-x11 libxkbcommon-x11-0 \
+        && rm -rf /var/lib/apt/lists/*
+
+# Copy preinstalled dependencies from compile image
+COPY --from=compile-image /opt/venv /opt/venv
 
 # Create user
 RUN useradd --create-home --home-dir /home/pyrdp pyrdp
 USER pyrdp
 
+# UTF-8 support on the console output (for pyrdp-player)
+ENV PYTHONIOENCODING=utf-8
+# Make sure we use the virtualenv:
+ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /home/pyrdp

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+# Install Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip \
+        # Required for local pip install
+        python3-setuptools \
+        # Required to build dbus-python
+        build-essential python3-dev \
+        libdbus-1-dev \
+        libdbus-glib-1-dev \
+        libgl1-mesa-glx \
+        notify-osd dbus-x11 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /pyrdp
+
+RUN cd /pyrdp \
+    && pip3 --no-cache-dir install -e . -U
+
+# Create user
+RUN useradd --create-home --home-dir /home/pyrdp pyrdp
+USER pyrdp
+
+WORKDIR /home/pyrdp

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,16 +1,18 @@
+#
+# This is a slimmer version of our docker image without the graphical player
+# and notification system integration.
+#
 # Handles compiling and package installation
 FROM ubuntu:18.04 AS compile-image
-# Install Dependencies
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip \
         # Required for local pip install
         python3-setuptools \
         # Required for venv setup
         python3-venv \
-        # Required to build RLE module and dbus-python
-        build-essential python3-dev \
-        libdbus-1-dev \
-        libdbus-glib-1-dev
+        # Required to build RLE module
+        build-essential python3-dev
 
 RUN python3 -m venv /opt/venv
 # Make sure we use the virtualenv:
@@ -23,18 +25,14 @@ COPY ext/rle.c /pyrdp/ext/rle.c
 COPY pyrdp/ /pyrdp/pyrdp/
 # Install in the virtualenv
 RUN cd /pyrdp \
-    && pip3 --no-cache-dir install .[GUI] -U
-
+    && pip3 --no-cache-dir install . -U
 
 # Handles runtime only (minimize size for distribution)
 FROM ubuntu:18.04 AS docker-image
 
-# Install Dependencies
+# Install runtime dependencies except pre-built venv
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
-        # GUI stuff
-        libgl1-mesa-glx \
-        notify-osd dbus-x11 libxkbcommon-x11-0 \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy preinstalled dependencies from compile image
 COPY --from=compile-image /opt/venv /opt/venv

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ This is the easiest installation method if you have docker installed and working
 docker pull gosecure/pyrdp:latest
 ```
 
+As an alternative we have a slimmer image without the GUI and ffmpeg dependencies.
+
+```
+docker pull gosecure/pyrdp:latest-slim
+```
+
 ### From Git Source
 
 We recommend installing PyRDP in a
@@ -132,15 +138,16 @@ Finally, you can install the project with Pip:
 ```
 pip3 install -U pip setuptools wheel
 
-# Without GUI dependencies
+# Without GUI and ffmpeg dependencies
 pip3 install -U -e .
 
-# With GUI dependencies
-pip3 install -U -e '.[GUI]'
+# With GUI and ffmpeg dependencies
+pip3 install -U -e '.[full]'
 ```
 
-This should install the dependencies required to run PyRDP. If you choose to install without GUI dependencies,
-it will not be possible to use `pyrdp-player` without headless mode (`--headless`)
+This should install the dependencies required to run PyRDP. If you choose to
+install without GUI or ffmpeg dependencies, it will not be possible to use
+`pyrdp-player` without headless mode (`--headless`) or `pyrdp-convert`.
 
 If you ever want to leave your virtual environment, you can simply deactivate it:
 
@@ -198,6 +205,12 @@ First of all, build the image by executing this command at the root of PyRDP (wh
 
 ```
 docker build -t pyrdp .
+```
+
+As an alternative we have a slimmer image without the GUI and ffmpeg dependencies:
+
+```
+docker build -f Dockerfile.slim -t pyrdp .
 ```
 
 Afterwards, you can execute PyRDP by invoking the `pyrdp` docker container. See [Usage instructions](#using-pyrdp) and the [Docker specific instructions](#docker-specific-usage-instructions) for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Uncomment a build section if you want to build your own image
     # Full image
     #build: .
-    # Slim image (no pyrdp-player, no pyrdp-convert)
+    # Slim image (no pyrdp-player without --headless and no pyrdp-convert)
     #build:
     #  context: .
     #  dockerfile: Dockerfile.slim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,17 @@
 version: "3"
 services:
   pyrdp:
-    build: .
+    image: gosecure/pyrdp:latest
+    # Slim image (no GUI pyrdp-player, no pyrdp-convert)
+    #image: gosecure/pyrdp:latest-slim
+    # Uncomment a build section if you want to build your own image
+    # Full image
+    #build: .
+    # Slim image (no pyrdp-player, no pyrdp-convert)
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile.slim
+
     # Uncomment this section only if you want to run the player.
     # This allows the GUI of the player to be displayed on the host screen and
     # stops Qt from using the MITM-SHM X11 Shared Memory Extension.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='pyrdp',
         'twisted',
     ],
     extras_require={
-        "GUI": ['PySide2', 'dbus-python;platform_system!="Windows"', 'notify2;platform_system!="Windows"']
+        "full": ['PySide2', 'dbus-python;platform_system!="Windows"', 'notify2;platform_system!="Windows"']
     }
 )


### PR DESCRIPTION
Since we merged #190 we can apply further sizing improvements to our docker image

* [x] Split GUI and not GUI into two images
* [x] Staged build to drastically reduce image size (no more `build-essentials` package required)
* [x] verify docker size improvements gains
* [x] Apply staged build to GUI Dockerfile
* [x] Add ~`integration-gui`~ `integration-slim` and ~`latest-gui`~ `latest-slim` tags to dockerhub automatic builds
* [x] update `docker-compose.yml` and documentation
* [x] add a `Dockerfile.slim` build in CI too

### Size reduction
* The integration image is 63.24 MB now. That is down from 252.39 MB now in master or down from 570.26 MB for 0.4.1.
* The integration-gui image is 293.32 MB now. That is up from 252.39 MB now in master (which I suspect was broken for the GUI since I needed to add a package to make it work on my system) or down from 570.26 MB for 0.4.1.

### Feedback required for Tag names
Because of @alxbl's upcoming work with video encoding and the needed dependencies, I'm not sure that `-gui` is the proper approach. Candidates:
* a) Current proposal: `latest` with minimal dependencies and `latest-gui` (with GUI but more later?)
* b) `latest` with minimal dependencies and `latest-full` (with everything)
* c) Turn it the other way around: `latest` with everything (GUI + video encoding, etc.) and `latest-slim` (I think python does it that way for official images)