### PR TITLE
Remove CI trigger on push, keep only on PRs and master pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   docker-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - *
+  push:
+    branches:
+      - master
 
 jobs:
   docker-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   pull_request:
     branches:
-      - *
+      - '**'
   push:
     branches:
       - master


### PR DESCRIPTION
This avoids the "double, identical CI runs" problem, and since we only work with PRs, it's not a problem to remove it. I kept CI run triggers on pushes to `master`
