### PR TITLE
Scale pyrdp-player replays with window height

### DIFF
--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -80,6 +80,7 @@ def main():
     if not args.headless:
         app = QApplication(sys.argv)
         mainWindow = MainWindow(args.bind, int(args.port), args.replay)
+        mainWindow.showMaximized()
         mainWindow.show()
 
         return app.exec_()

--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -9,7 +9,9 @@
 # asyncio needs to be imported first to ensure that the reactor is
 # installed properly. Do not re-order.
 import asyncio
+
 from twisted.internet import asyncioreactor
+
 asyncioreactor.install(asyncio.get_event_loop())
 
 from pyrdp.core import settings
@@ -17,7 +19,6 @@ from pyrdp.logging import LOGGER_NAMES, NotifyHandler, configure as configureLog
 from pyrdp.player import HAS_GUI
 from pyrdp.player.config import DEFAULTS
 
-from pathlib import Path
 import argparse
 import logging
 import logging.handlers

--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -7,9 +7,9 @@
 #
 
 # asyncio needs to be imported first to ensure that the reactor is
-# installed properly. Do not re-order.
+# installed properly. ***DO NOT RE-ORDER***.
+import asyncio  # noqa
 
-import asyncio   # noqa
 from twisted.internet import asyncioreactor
 
 asyncioreactor.install(asyncio.get_event_loop())

--- a/pyrdp/player/BaseTab.py
+++ b/pyrdp/player/BaseTab.py
@@ -33,11 +33,12 @@ class BaseTab(QWidget):
         self.text.setMinimumHeight(150)
         self.log = logging.getLogger(LOGGER_NAMES.PLAYER)
 
-        scrollViewer = QScrollArea()
-        scrollViewer.setWidget(self.widget)
-
         self.tabLayout = QVBoxLayout()
-        self.tabLayout.addWidget(scrollViewer, 8)
+
+        self.scrollViewer = QScrollArea()
+        self.scrollViewer.setWidget(self.widget)
+
+        self.tabLayout.addWidget(self.scrollViewer, 10)
         self.tabLayout.addWidget(self.text, 2)
 
         self.setLayout(self.tabLayout)

--- a/pyrdp/player/BaseTab.py
+++ b/pyrdp/player/BaseTab.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/LiveTab.py
+++ b/pyrdp/player/LiveTab.py
@@ -9,12 +9,12 @@ import asyncio
 from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QHBoxLayout, QWidget
 
+from pyrdp.mitm.PlayerLayerSet import AsyncIOPlayerLayerSet
 from pyrdp.player.AttackerBar import AttackerBar
 from pyrdp.player.BaseTab import BaseTab
 from pyrdp.player.filesystem import DirectoryObserver, FileSystem
 from pyrdp.player.FileSystemWidget import FileSystemWidget
 from pyrdp.player.LiveEventHandler import LiveEventHandler
-from pyrdp.mitm.PlayerLayerSet import AsyncIOPlayerLayerSet
 from pyrdp.player.RDPMITMWidget import RDPMITMWidget
 
 
@@ -23,7 +23,7 @@ class LiveTab(BaseTab, DirectoryObserver):
     Tab playing a live RDP connection as data is being received over the network.
     """
 
-    def __init__(self, parent: QWidget = None):
+    def __init__(self, parent: QWidget):
         layers = AsyncIOPlayerLayerSet()
         rdpWidget = RDPMITMWidget(1024, 768, layers.player)
 

--- a/pyrdp/player/LiveTab.py
+++ b/pyrdp/player/LiveTab.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018, 2019 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -15,6 +15,7 @@ from pyrdp.player.BaseWindow import BaseWindow
 from pyrdp.player.LiveTab import LiveTab
 from pyrdp.player.LiveThread import LiveThread
 
+
 class LiveWindow(BaseWindow):
     """
     Class that holds logic for live player (network RDP connections as they happen) tabs.
@@ -23,7 +24,7 @@ class LiveWindow(BaseWindow):
     connectionReceived = Signal()
     closedTabText = " - Closed"
 
-    def __init__(self, address: str, port: int, updateCountSignal: Signal, options: Dict[str, object], parent: QWidget = None):
+    def __init__(self, address: str, port: int, updateCountSignal: Signal, options: Dict[str, object], parent: QWidget):
         super().__init__(options, parent)
 
         QApplication.instance().aboutToQuit.connect(self.onClose)
@@ -40,7 +41,7 @@ class LiveWindow(BaseWindow):
         return tab.getProtocol()
 
     def createLivePlayerTab(self):
-        tab = LiveTab()
+        tab = LiveTab(parent=self)
         tab.addIconToTab.connect(self.addIconToTab)
         tab.renameTab.connect(self.renameLivePlayerTab)
         tab.connectionClosed.connect(self.onConnectionClosed)

--- a/pyrdp/player/LiveWindow.py
+++ b/pyrdp/player/LiveWindow.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019, 2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -3,10 +3,13 @@
 # Copyright (C) 2018, 2019 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
+from typing import List
 
 from PySide2.QtCore import Qt, Signal
-from PySide2.QtWidgets import QAction, QFileDialog, QMainWindow, QTabWidget, QInputDialog
+from PySide2.QtGui import QResizeEvent
+from PySide2.QtWidgets import QAction, QFileDialog, QInputDialog, QMainWindow, QTabWidget
 
+from pyrdp.player import BaseTab
 from pyrdp.player.LiveWindow import LiveWindow
 from pyrdp.player.ReplayWindow import ReplayWindow
 
@@ -32,13 +35,14 @@ class MainWindow(QMainWindow):
             "closeTabOnCtrlW": True     # Allow user to toggle Ctrl+W passthrough.
         }
 
-        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options)
-        self.replayWindow = ReplayWindow(self.options)
+        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options, mainWindow=self)
+        self.replayWindow = ReplayWindow(self.options, mainWindow=self)
         self.tabManager = QTabWidget()
         self.tabManager.addTab(self.liveWindow, "Live connections")
         self.tabManager.addTab(self.replayWindow, "Replays")
         self.setCentralWidget(self.tabManager)
         self.updateCountSignal.connect(self.updateTabConnectionCount)
+        self.resizeObservers: List[BaseTab] = []
 
         # File menu
         openAction = QAction("Open...", self)
@@ -110,7 +114,6 @@ class MainWindow(QMainWindow):
             for fileName in fileNames:
                 self.replayWindow.openFile(fileName)
 
-
     def sendKeySequence(self, keys: [Qt.Key]):
         if self.tabManager.currentWidget() is self.liveWindow:
             self.liveWindow.sendKeySequence(keys)
@@ -138,3 +141,12 @@ class MainWindow(QMainWindow):
         """
 
         self.tabManager.setTabText(0, "Live connections (%d)" % self.liveWindow.count())
+
+    def addObserver(self, observer: BaseTab):
+        self.resizeObservers.append(observer)
+        observer.mainWindowResized(self.width(), self.height())
+
+    def resizeEvent(self, event: QResizeEvent):
+        for observer in self.resizeObservers:
+            observer.mainWindowResized(event.size().width(), event.size().height())
+        super().resizeEvent(event)

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018, 2019 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 from typing import List

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -35,7 +35,7 @@ class MainWindow(QMainWindow):
         }
 
         self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options, parent=self)
-        self.replayWindow = ReplayWindow(self.options, mainWindow=self, parent=self)
+        self.replayWindow = ReplayWindow(self.options, parent=self)
         self.tabManager = QTabWidget()
         self.tabManager.addTab(self.liveWindow, "Live connections")
         self.tabManager.addTab(self.replayWindow, "Replays")

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -6,7 +6,6 @@
 from typing import List
 
 from PySide2.QtCore import Qt, Signal
-from PySide2.QtGui import QResizeEvent
 from PySide2.QtWidgets import QAction, QFileDialog, QInputDialog, QMainWindow, QTabWidget
 
 from pyrdp.player import BaseTab
@@ -35,8 +34,8 @@ class MainWindow(QMainWindow):
             "closeTabOnCtrlW": True     # Allow user to toggle Ctrl+W passthrough.
         }
 
-        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options)
-        self.replayWindow = ReplayWindow(self.options, mainWindow=self)
+        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options, parent=self)
+        self.replayWindow = ReplayWindow(self.options, mainWindow=self, parent=self)
         self.tabManager = QTabWidget()
         self.tabManager.addTab(self.liveWindow, "Live connections")
         self.tabManager.addTab(self.replayWindow, "Replays")
@@ -141,12 +140,3 @@ class MainWindow(QMainWindow):
         """
 
         self.tabManager.setTabText(0, "Live connections (%d)" % self.liveWindow.count())
-
-    def addObserver(self, observer: BaseTab):
-        self.resizeObservers.append(observer)
-        observer.mainWindowResized(self.width(), self.height())
-
-    def resizeEvent(self, event: QResizeEvent):
-        for observer in self.resizeObservers:
-            observer.mainWindowResized(event.size().width(), event.size().height())
-        super().resizeEvent(event)

--- a/pyrdp/player/MainWindow.py
+++ b/pyrdp/player/MainWindow.py
@@ -35,7 +35,7 @@ class MainWindow(QMainWindow):
             "closeTabOnCtrlW": True     # Allow user to toggle Ctrl+W passthrough.
         }
 
-        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options, mainWindow=self)
+        self.liveWindow = LiveWindow(bind_address, port, self.updateCountSignal, self.options)
         self.replayWindow = ReplayWindow(self.options, mainWindow=self)
         self.tabManager = QTabWidget()
         self.tabManager.addTab(self.liveWindow, "Live connections")

--- a/pyrdp/player/ReplayBar.py
+++ b/pyrdp/player/ReplayBar.py
@@ -6,7 +6,8 @@
 import logging
 
 from PySide2.QtCore import Qt, Signal
-from PySide2.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QSpacerItem, QVBoxLayout, QWidget
+from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QSizePolicy, QSlider, QSpacerItem, \
+    QVBoxLayout, QWidget
 
 from pyrdp.logging import LOGGER_NAMES
 from pyrdp.player.SeekBar import SeekBar
@@ -31,6 +32,8 @@ class ReplayBar(QWidget):
         self.button.setMaximumWidth(100)
         self.button.clicked.connect(self.onButtonClicked)
 
+        self.scaleCheckbox = QCheckBox("Scale to window")
+
         self.timeSlider = SeekBar()
         self.timeSlider.setMinimum(0)
         self.timeSlider.setMaximum(int(duration * 1000))
@@ -49,6 +52,7 @@ class ReplayBar(QWidget):
         horizontal = QHBoxLayout()
         horizontal.addWidget(self.speedLabel)
         horizontal.addWidget(self.speedSlider)
+        horizontal.addWidget(self.scaleCheckbox)
         horizontal.addItem(QSpacerItem(20, 40, QSizePolicy.Expanding, QSizePolicy.Expanding))
         vertical.addLayout(horizontal)
 

--- a/pyrdp/player/ReplayBar.py
+++ b/pyrdp/player/ReplayBar.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 import logging

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -108,4 +108,3 @@ class ReplayTab(BaseTab):
         """
         newScale = (self.scrollViewer.height() - self.scrollViewer.horizontalScrollBar().height()) / self.widget.sessionHeight
         self.widget.scale(newScale)
-        self.thread.parentResized()

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019, 2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 from PySide2.QtGui import QResizeEvent

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -45,6 +45,7 @@ class ReplayTab(BaseTab):
         self.controlBar.pause.connect(self.thread.pause)
         self.controlBar.seek.connect(self.thread.seek)
         self.controlBar.speedChanged.connect(self.thread.setSpeed)
+        self.controlBar.scaleCheckbox.stateChanged.connect(self.widget.setScaleToWindow)
         self.controlBar.button.setDefault(True)
 
         self.tabLayout.insertWidget(0, self.controlBar)

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -103,8 +103,7 @@ class ReplayTab(BaseTab):
         """
         Called when the main PyRDP window is resized to allow to scale the current
         RDP session being displayed.
-        :param width: The new width of the main window
-        :param height: The new height of the main window
+        :param event: The event of the parent that has been resized
         """
         newScale = (self.scrollViewer.height() - self.scrollViewer.horizontalScrollBar().height()) / self.widget.sessionHeight
         self.widget.scale(newScale)

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -88,3 +88,13 @@ class ReplayTab(BaseTab):
     def onClose(self):
         self.thread.close()
         self.thread.wait()
+
+    def mainWindowResized(self, width: int, height: int):
+        """
+        Called when the main PyRDP window is resized to allow to scale the current
+        RDP session being displayed.
+        :param width: The new width of the main window
+        :param height: The new height of the main window
+        """
+        self.widget.scale((height - self.text.height() - 200) / self.widget.height)
+        self.thread.mainWindowResized()

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
-
+from PySide2.QtGui import QResizeEvent
 from PySide2.QtWidgets import QApplication, QWidget
 
 from pyrdp.layer import PlayerLayer
@@ -99,7 +99,7 @@ class ReplayTab(BaseTab):
         self.parentResized(self.parent().width(), self.parent().height())
         self.widget.setScaleToWindow(status)
 
-    def parentResized(self, width: int, height: int):
+    def parentResized(self, event: QResizeEvent):
         """
         Called when the main PyRDP window is resized to allow to scale the current
         RDP session being displayed.

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -96,7 +96,7 @@ class ReplayTab(BaseTab):
         the scaling calculation.
         :param status: state of the checkbox
         """
-        self.parentResized(self.parent().width(), self.parent().height())
+        self.parentResized(None)
         self.widget.setScaleToWindow(status)
 
     def parentResized(self, event: QResizeEvent):

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -97,5 +97,5 @@ class ReplayTab(BaseTab):
         :param width: The new width of the main window
         :param height: The new height of the main window
         """
-        self.widget.scale((height - self.text.height() - 200) / self.widget.height)
+        self.widget.scale((height - self.text.height() - 200) / self.widget.sessionHeight)
         self.thread.mainWindowResized()

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -20,7 +20,7 @@ class ReplayTab(BaseTab):
     Tab that displays a RDP Connection that is being replayed from a file.
     """
 
-    def __init__(self, fileName: str, parent: QWidget = None):
+    def __init__(self, fileName: str, parent: QWidget):
         """
         :param fileName: name of the file to read.
         :param parent: parent widget.
@@ -45,7 +45,7 @@ class ReplayTab(BaseTab):
         self.controlBar.pause.connect(self.thread.pause)
         self.controlBar.seek.connect(self.thread.seek)
         self.controlBar.speedChanged.connect(self.thread.setSpeed)
-        self.controlBar.scaleCheckbox.stateChanged.connect(self.widget.setScaleToWindow)
+        self.controlBar.scaleCheckbox.stateChanged.connect(self.setScaleToWindow)
         self.controlBar.button.setDefault(True)
 
         self.tabLayout.insertWidget(0, self.controlBar)
@@ -90,12 +90,22 @@ class ReplayTab(BaseTab):
         self.thread.close()
         self.thread.wait()
 
-    def mainWindowResized(self, width: int, height: int):
+    def setScaleToWindow(self, status: int):
+        """
+        Called when the scale to window checkbox is checked or unchecked, refresh
+        the scaling calculation.
+        :param status: state of the checkbox
+        """
+        self.parentResized(self.parent().width(), self.parent().height())
+        self.widget.setScaleToWindow(status)
+
+    def parentResized(self, width: int, height: int):
         """
         Called when the main PyRDP window is resized to allow to scale the current
         RDP session being displayed.
         :param width: The new width of the main window
         :param height: The new height of the main window
         """
-        self.widget.scale((height - self.text.height() - 200) / self.widget.sessionHeight)
-        self.thread.mainWindowResized()
+        newScale = (self.scrollViewer.height() - self.scrollViewer.horizontalScrollBar().height()) / self.widget.sessionHeight
+        self.widget.scale(newScale)
+        self.thread.parentResized()

--- a/pyrdp/player/ReplayThread.py
+++ b/pyrdp/player/ReplayThread.py
@@ -109,7 +109,7 @@ class ReplayThread(QThread):
     def close(self):
         self.queue.put(ReplayThreadEvent.EXIT)
 
-    def mainWindowResized(self):
+    def parentResized(self):
         """
         Seeks to current time to allow to rerender the image on the resized widget.
         """

--- a/pyrdp/player/ReplayThread.py
+++ b/pyrdp/player/ReplayThread.py
@@ -108,10 +108,3 @@ class ReplayThread(QThread):
 
     def close(self):
         self.queue.put(ReplayThreadEvent.EXIT)
-
-    def parentResized(self):
-        """
-        Seeks to current time to allow to rerender the image on the resized widget.
-        """
-        self.lastSeekTime = self.timer.getElapsedTime()
-        self.queue.put(ReplayThreadEvent.SEEK)

--- a/pyrdp/player/ReplayThread.py
+++ b/pyrdp/player/ReplayThread.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -9,7 +9,6 @@ from typing import Dict
 from PySide2.QtGui import QResizeEvent
 from PySide2.QtWidgets import QWidget
 
-from pyrdp.player import MainWindow
 from pyrdp.player.BaseWindow import BaseWindow
 from pyrdp.player.ReplayTab import ReplayTab
 
@@ -19,9 +18,8 @@ class ReplayWindow(BaseWindow):
     Class for managing replay tabs.
     """
 
-    def __init__(self, options: Dict[str, object], mainWindow: MainWindow, parent: QWidget):
+    def __init__(self, options: Dict[str, object], parent: QWidget):
         super().__init__(options, parent=parent)
-        self.mainWindow = mainWindow
 
     def openFile(self, fileName: str, autoplay: bool = False):
         """

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -6,6 +6,7 @@
 
 from typing import Dict
 
+from PySide2.QtGui import QResizeEvent
 from PySide2.QtWidgets import QWidget
 
 from pyrdp.player import MainWindow
@@ -18,7 +19,7 @@ class ReplayWindow(BaseWindow):
     Class for managing replay tabs.
     """
 
-    def __init__(self, options: Dict[str, object], mainWindow: MainWindow, parent: QWidget = None):
+    def __init__(self, options: Dict[str, object], mainWindow: MainWindow, parent: QWidget):
         super().__init__(options, parent=parent)
         self.mainWindow = mainWindow
 
@@ -27,9 +28,13 @@ class ReplayWindow(BaseWindow):
         Open a replay file and open a new tab.
         :param fileName: replay path.
         """
-        tab = ReplayTab(fileName)
-        self.mainWindow.addObserver(tab)
+        tab = ReplayTab(fileName, parent=self)
         self.addTab(tab, fileName)
         self.log.debug("Loading replay file %(arg1)s", {"arg1": fileName})
         if autoplay:
             tab.play()
+
+    def resizeEvent(self, event: QResizeEvent):
+        super().resizeEvent(event)
+        for i in range(self.count()):
+            self.widget(i).parentResized(event.size().width(), event.size().height())

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 from PySide2.QtWidgets import QWidget
 
+from pyrdp.player import MainWindow
 from pyrdp.player.BaseWindow import BaseWindow
 from pyrdp.player.ReplayTab import ReplayTab
 
@@ -17,8 +18,9 @@ class ReplayWindow(BaseWindow):
     Class for managing replay tabs.
     """
 
-    def __init__(self, options: Dict[str, object], parent: QWidget = None):
-        super().__init__(options, parent)
+    def __init__(self, options: Dict[str, object], mainWindow: MainWindow, parent: QWidget = None):
+        super().__init__(options, parent=parent)
+        self.mainWindow = mainWindow
 
     def openFile(self, fileName: str, autoplay: bool = False):
         """
@@ -26,6 +28,7 @@ class ReplayWindow(BaseWindow):
         :param fileName: replay path.
         """
         tab = ReplayTab(fileName)
+        self.mainWindow.addObserver(tab)
         self.addTab(tab, fileName)
         self.log.debug("Loading replay file %(arg1)s", {"arg1": fileName})
         if autoplay:

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019, 2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/ReplayWindow.py
+++ b/pyrdp/player/ReplayWindow.py
@@ -37,4 +37,4 @@ class ReplayWindow(BaseWindow):
     def resizeEvent(self, event: QResizeEvent):
         super().resizeEvent(event)
         for i in range(self.count()):
-            self.widget(i).parentResized(event.size().width(), event.size().height())
+            self.widget(i).parentResized(event)

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -195,9 +195,10 @@ class QRemoteDesktop(QWidget):
 
     def resize(self, width: int, height: int):
         """
-        Resize widget
-        :param width: new width of the widget
-        :param height: new height of the widget
+        Resize the image buffer. This is called when the clientData is parsed, which
+        contains the screen size used for the connection.
+        :param width: new width of the replay client's screen
+        :param height: new height of the replay client's screen.
         """
         self._buffer = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
         self.sessionWidth = width

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -145,13 +145,13 @@ class QRemoteDesktop(QWidget):
 
         self.scaleToWindow = False
 
+        # Buffer image
         self._buffer: QImage = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
 
         # Set correct size
         self.resize(width, height)
         # Bind mouse event
         self.setMouseTracking(True)
-        # Buffer image
         self.mouseX = width // 2
         self.mouseY = height // 2
 

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -141,12 +141,13 @@ class QRemoteDesktop(QWidget):
 
         self.scaleToWindow = False
 
+        self._buffer: QImage = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
+
         # Set correct size
         self.resize(width, height)
         # Bind mouse event
         self.setMouseTracking(True)
         # Buffer image
-        self._buffer = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
         self.mouseX = width // 2
         self.mouseY = height // 2
 
@@ -197,7 +198,7 @@ class QRemoteDesktop(QWidget):
         :param width: new width of the widget
         :param height: new height of the widget
         """
-        self._buffer = QImage(width, height, QImage.Format_RGB32)
+        self._buffer = self._buffer.scaled(width, height)
         self.sessionWidth = width
         self.sessionHeight = height
         super().resize(width, height)
@@ -214,6 +215,6 @@ class QRemoteDesktop(QWidget):
         qp.drawEllipse(QPoint(self.mouseX * scaleValue, self.mouseY * scaleValue), 5, 5)
 
     def clear(self):
-        self._buffer = QImage(self._buffer.width(), self._buffer.height(), QImage.Format_RGB32)
+        self._buffer = QImage(self._buffer.width(), self._buffer.height(), QImage.Format_ARGB32_Premultiplied)
         self.setMousePosition(self._buffer.width() // 2, self._buffer.height() // 2)
         self.repaint()

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -137,7 +137,9 @@ class QRemoteDesktop(QWidget):
         """
         super().__init__(parent)
 
-        self.scaleValue = 1
+        self.ratio = 1
+        """ Scale factor used to render the RDP session on the player."""
+
         self.sessionWidth = width
         self.sessionHeight = height
 
@@ -188,7 +190,7 @@ class QRemoteDesktop(QWidget):
         Rescale the current widget to a percentage of the height of the RDP session.
         :param scale: Ex: 0.5 for 50% height and 50% width.
         """
-        self.scaleValue = scale
+        self.ratio = scale
 
     def setScaleToWindow(self, status):
         self.scaleToWindow = status > 0
@@ -210,11 +212,11 @@ class QRemoteDesktop(QWidget):
         Call when Qt renderer engine estimate that is needed
         :param e: the event
         """
-        scaleValue = self.scaleValue if self.scaleToWindow else 1
+        ratio = self.ratio if self.scaleToWindow else 1
         qp = QPainter(self)
-        qp.drawImage(0, 0, self._buffer.scaled(self.sessionWidth * scaleValue, self.sessionHeight * scaleValue, aspectMode=Qt.KeepAspectRatio))
+        qp.drawImage(0, 0, self._buffer.scaled(self.sessionWidth * ratio, self.sessionHeight * ratio, aspectMode=Qt.KeepAspectRatio))
         qp.setBrush(QColor.fromRgb(255, 255, 0, 180))
-        qp.drawEllipse(QPoint(self.mouseX * scaleValue, self.mouseY * scaleValue), 5, 5)
+        qp.drawEllipse(QPoint(self.mouseX * ratio, self.mouseY * ratio), 5, 5)
 
     def clear(self):
         self._buffer = QImage(self._buffer.width(), self._buffer.height(), QImage.Format_ARGB32_Premultiplied)

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2014-2015 Sylvain Peyrefitte
 # Copyright (c) 2018-2020 GoSecure Inc.
 #
-# This file is part of rdpy.
+# This file is part of PyRDP.
+# This file was part of rdpy.
+#
+# PyRDP is licensed under the GPLv3 or later.
 #
 # rdpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -189,7 +189,6 @@ class QRemoteDesktop(QWidget):
         :param scale: Ex: 0.5 for 50% height and 50% width.
         """
         self.scaleValue = scale
-        self.resize(self.sessionWidth, self.sessionHeight)
 
     def setScaleToWindow(self, status):
         self.scaleToWindow = status > 0
@@ -200,7 +199,7 @@ class QRemoteDesktop(QWidget):
         :param width: new width of the widget
         :param height: new height of the widget
         """
-        self._buffer = self._buffer.scaled(width, height)
+        self._buffer = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
         self.sessionWidth = width
         self.sessionHeight = height
         super().resize(width, height)

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -136,8 +136,8 @@ class QRemoteDesktop(QWidget):
         super().__init__(parent)
 
         self.scaleValue = 1
-        self.width = width
-        self.height = height
+        self.sessionWidth = width
+        self.sessionHeight = height
 
         self.scaleToWindow = False
 
@@ -186,7 +186,7 @@ class QRemoteDesktop(QWidget):
         :param scale: Ex: 0.5 for 50% height and 50% width.
         """
         self.scaleValue = scale
-        self.resize(self.width, self.height)
+        self.resize(self.sessionWidth, self.sessionHeight)
 
     def setScaleToWindow(self, status):
         self.scaleToWindow = status > 0
@@ -198,8 +198,8 @@ class QRemoteDesktop(QWidget):
         :param height: new height of the widget
         """
         self._buffer = QImage(width, height, QImage.Format_RGB32)
-        self.width = width
-        self.height = height
+        self.sessionWidth = width
+        self.sessionHeight = height
         super().resize(width, height)
 
     def paintEvent(self, e: QEvent):
@@ -209,7 +209,7 @@ class QRemoteDesktop(QWidget):
         """
         scaleValue = self.scaleValue if self.scaleToWindow else 1
         qp = QPainter(self)
-        qp.drawImage(0, 0, self._buffer.scaled(self.width * scaleValue, self.height * scaleValue, aspectMode=Qt.KeepAspectRatio))
+        qp.drawImage(0, 0, self._buffer.scaled(self.sessionWidth * scaleValue, self.sessionHeight * scaleValue, aspectMode=Qt.KeepAspectRatio))
         qp.setBrush(QColor.fromRgb(255, 255, 0, 180))
         qp.drawEllipse(QPoint(self.mouseX * scaleValue, self.mouseY * scaleValue), 5, 5)
 

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -122,8 +122,10 @@ def convert8bppTo16bpp(buf: bytes):
 
 class QRemoteDesktop(QWidget):
     """
-    Qt RDP display widget
+    Qt RDP display widget. It is the widget directly responsible to display the "screen" of the
+    client in the RDP session being shown/replayed.
     """
+
     # This signal can be used by other objects to run code on the main thread. The argument is a callable.
     mainThreadHook = Signal(object)
 

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -139,6 +139,8 @@ class QRemoteDesktop(QWidget):
         self.width = width
         self.height = height
 
+        self.scaleToWindow = False
+
         # set correct size
         self.resize(width, height)
         # bind mouse event
@@ -183,6 +185,9 @@ class QRemoteDesktop(QWidget):
         self.scaleValue = scale
         self.resize(self.width, self.height)
 
+    def setScaleToWindow(self, status):
+        self.scaleToWindow = status > 0
+
     def resize(self, width: int, height: int):
         """
         Resize widget
@@ -192,17 +197,18 @@ class QRemoteDesktop(QWidget):
         self._buffer = QImage(width, height, QImage.Format_RGB32)
         self.width = width
         self.height = height
-        super().resize(width * self.scaleValue, height * self.scaleValue)
+        super().resize(width, height)
 
     def paintEvent(self, e: QEvent):
         """
         Call when Qt renderer engine estimate that is needed
         :param e: the event
         """
+        scaleValue = self.scaleValue if self.scaleToWindow else 1
         qp = QPainter(self)
-        qp.drawImage(0, 0, self._buffer.scaled(self.width * self.scaleValue, self.height * self.scaleValue, aspectMode=Qt.KeepAspectRatio))
+        qp.drawImage(0, 0, self._buffer.scaled(self.width * scaleValue, self.height * scaleValue, aspectMode=Qt.KeepAspectRatio))
         qp.setBrush(QColor.fromRgb(255, 255, 0, 180))
-        qp.drawEllipse(QPoint(self.mouseX * self.scaleValue, self.mouseY * self.scaleValue), 5, 5)
+        qp.drawEllipse(QPoint(self.mouseX * scaleValue, self.mouseY * scaleValue), 5, 5)
 
     def clear(self):
         self._buffer = QImage(self._buffer.width(), self._buffer.height(), QImage.Format_RGB32)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/14599855/78849011-54786400-79e1-11ea-9d7f-af94c4773ac0.png)

![image](https://user-images.githubusercontent.com/14599855/78848976-3ca0e000-79e1-11ea-9450-d247aa49ab39.png)


Works ONLY on replays, not on the live player tab (because I was too scared to commit to testing the whole session takeover feature to be bug free).

~Right now, I will keep it as a draft because it is the default option, but I want to have a checkbox where we can choose to scale or not.~

EDIT: Checkbox has been implemented, images updated

Also maximizes pyrdp-player upon launch

Fixes #101 