### PR TITLE
Add support for Ehanced Security Direct Connection

### DIFF
--- a/pyrdp/mitm/PlayerLayerSet.py
+++ b/pyrdp/mitm/PlayerLayerSet.py
@@ -1,15 +1,16 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 from pyrdp.layer import AsyncIOTCPLayer, LayerChainItem, PlayerLayer, TwistedTCPLayer
+from pyrdp.mitm import MITMConfig
 
 
 class TwistedPlayerLayerSet:
-    def __init__(self):
-        self.tcp = TwistedTCPLayer()
+    def __init__(self, config: MITMConfig):
+        self.tcp = TwistedTCPLayer(config)
         self.player = PlayerLayer()
         LayerChainItem.chain(self.tcp, self.player)
 

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -76,13 +76,13 @@ class RDPMITM:
         self.state = state if state is not None else RDPMITMState(self.config)
         """The MITM state"""
 
-        self.client = RDPLayerSet()
+        self.client = RDPLayerSet(self.config)
         """Layers on the client side"""
 
-        self.server = RDPLayerSet()
+        self.server = RDPLayerSet(self.config)
         """Layers on the server side"""
 
-        self.player = TwistedPlayerLayerSet()
+        self.player = TwistedPlayerLayerSet(self.config)
         """Layers on the attacker side"""
 
         self.recorder = recorder if recorder is not None else MITMRecorder([], self.state)

--- a/pyrdp/mitm/layerset.py
+++ b/pyrdp/mitm/layerset.py
@@ -1,10 +1,11 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 from pyrdp.enum import SegmentationPDUType
+from pyrdp.mitm import MITMConfig
 from pyrdp.layer import FastPathLayer, LayerChainItem, MCSLayer, SecurityLayer, SegmentationLayer, SlowPathLayer, \
     TPKTLayer, TwistedTCPLayer, X224Layer
 
@@ -14,8 +15,8 @@ class RDPLayerSet:
     Class that handles initialization of regular (non-virtual channel) RDP layers.
     """
 
-    def __init__(self):
-        self.tcp = TwistedTCPLayer()
+    def __init__(self, config: MITMConfig):
+        self.tcp = TwistedTCPLayer(config)
         self.segmentation = SegmentationLayer()
         self.tpkt = TPKTLayer()
         self.x224 = X224Layer()


### PR DESCRIPTION
This is a DRAFT pull request that modifies PyRDP to support the direct connection approach outlined in [1.3.1.2 Security-Enhanced Connection Sequence](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/49e2791f-72d0-4229-92b7-8f32c48a7206).

I think it still needs some work because it relies on private Twisted APIs (Unavoidable?) and propagates the MITM config into non-MITM modules, which feels unclean.

I would like to also refactor the MITM Config to split the MITM specific settings and the Core settings. This could also plug into the `.ini` configuration files while we're playing in that code area.

I'm opening the PR now in case someone has time (and wants) to work on it.