### PR TITLE
Minor tweaks to the window scaling code

### DIFF
--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -105,5 +105,5 @@ class ReplayTab(BaseTab):
         RDP session being displayed.
         :param event: The event of the parent that has been resized
         """
-        newScale = (self.scrollViewer.height() - self.scrollViewer.horizontalScrollBar().height()) / self.widget.sessionHeight
+        newScale = self.scrollViewer.viewport().height() / self.widget.sessionHeight
         self.widget.scale(newScale)

--- a/pyrdp/player/ReplayTab.py
+++ b/pyrdp/player/ReplayTab.py
@@ -96,8 +96,8 @@ class ReplayTab(BaseTab):
         the scaling calculation.
         :param status: state of the checkbox
         """
-        self.parentResized(None)
         self.widget.setScaleToWindow(status)
+        self.parentResized(None)
 
     def parentResized(self, event: QResizeEvent):
         """

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -194,6 +194,18 @@ class QRemoteDesktop(QWidget):
         :param scale: Ex: 0.5 for 50% height and 50% width.
         """
         self.ratio = scale
+        self._updateWidgetSize()
+
+    def _updateWidgetSize(self):
+        """
+        Size the widget according to if we are scaled or not
+        """
+        if self.scaleToWindow:
+            # resize widget to parent size: will hide scrollbars
+            super().resize(self.parent().size())
+        else:
+            # resize widget to session size: will show scrollbars if required
+            super().resize(self.sessionWidth, self.sessionHeight)
 
     def setScaleToWindow(self, status):
         self.scaleToWindow = status > 0
@@ -208,7 +220,7 @@ class QRemoteDesktop(QWidget):
         self._buffer = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
         self.sessionWidth = width
         self.sessionHeight = height
-        super().resize(width, height)
+        self._updateWidgetSize()
 
     def paintEvent(self, e: QEvent):
         """

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -166,6 +166,7 @@ class QRemoteDesktop(QWidget):
     @property
     def screen(self):
         return self._buffer
+
     def notifyImage(self, x: int, y: int, qimage: QImage, width: int, height: int):
         """
         Draw an image on the buffer.


### PR DESCRIPTION
Two main changes

### Scrollbar only displayed if replay is not scaled (the default)

It's fixed. Dispatched events needed to be re-ordered because resize was called before QRemoteDesktop's state was updated and I was querying it.

### Few pixels were missing when scaled

Before change:
![pyrdp-pixels-grugés](https://user-images.githubusercontent.com/546325/79378937-212b5d00-7f2c-11ea-9cfa-d2582e41cb7c.png)

After change:
![pyrdp-pixels-ok](https://user-images.githubusercontent.com/546325/79378996-30aaa600-7f2c-11ea-9c55-8d96236cdf6e.png)

The difference between using the viewport() and the height minus scrollbar height is 2 pixels but that was enough to be perceptible.