### PR TITLE
Fix CI not completely running on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: pyrdp-mitm.py initialization test
         working-directory: ./
-        run: python bin/pyrdp-mitm.py --test localhost
+        run: python test/test_mitm_initialization.py dummy_value
 
       - name: pyrdp-player.py read a replay in headless mode test
         working-directory: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: pyrdp-mitm.py initialization test
         working-directory: ./
-        run: bin/pyrdp-mitm.py --test localhost
+        run: python bin/pyrdp-mitm.py --test localhost
 
       - name: pyrdp-player.py read a replay in headless mode test
         working-directory: ./
-        run: bin/pyrdp-player.py --headless test/files/test_session.replay
+        run: python bin/pyrdp-player.py --headless test/files/test_session.replay


### PR DESCRIPTION
~The latest CI failure made me wonder why it failed on ubuntu and not on windows even though I tested it to fail on my windows machine as well. I think I spotted the bug (currently testing)~

## The problem:
The CI used powershell with this to run the desired command: 
![image](https://user-images.githubusercontent.com/14599855/79479794-4a56f680-7fdb-11ea-925c-86bf6475dfa2.png)

For some reason, running directly the python script seemed to act as a NOOP and exited with code 0, making the CI step a success even though the CI didn't actually execute the script.

## The fix:
call `python` before the script so it actually runs