### PR TITLE
CI installs the full package (GUI+AV) instead of slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo apt install libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx git python3-dev
     - name: Install PyRDP
       working-directory: .
-      run: pip install -U -e .
+      run: pip install -U -e .[full]
 
     - name: Install ci dependencies
       run: pip install -r requirements-ci.txt
@@ -85,7 +85,7 @@ jobs:
         run: pip --version
       - name: Install PyRDP
         working-directory: .
-        run: pip install -U -e .
+        run: pip install -U -e .[full]
 
       - name: Extract test files
         uses: DuckSoft/extract-7z-action@v1.0


### PR DESCRIPTION
It will catch more errors as they are introduced. For example, adding the ffmpeg dependency will fail a build on Ubuntu 18.04. The docker build caught it but not the Ubuntu install.

I think doing it on Windows would be good too. Hopefully, we will be able to turn it on.

I expect this PR to be rocky with failures and finish with a squash merge.