### PR TITLE
Install openssl in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ FROM ubuntu:18.04 AS docker-image
 
 # Install runtime dependencies except pre-built venv
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+        openssl \
         # GUI and notifications stuff
         libgl1-mesa-glx \
         notify-osd dbus-x11 libxkbcommon-x11-0 \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -32,6 +32,7 @@ FROM ubuntu:18.04 AS docker-image
 
 # Install runtime dependencies except pre-built venv
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy preinstalled dependencies from compile image


### PR DESCRIPTION
OpenSSL was not installed in the runtime image, so the MITM probably wasnt working at all. I'm not sure how that could be tested in the CI.

Fixes #216 