### PR TITLE
feat: Added CredSSP support when private key is known

### DIFF
--- a/docs/cert-extraction.md
+++ b/docs/cert-extraction.md
@@ -4,7 +4,7 @@ This procedure is useful when running honeypots to support CredSSP (using `--aut
 It requires Administrative privileges on the target server and the use of Mimikatz, so it assumes that you are able to deactivate the Anti-Virus on the target server.
 
 
-> **WARNING**: Cloning the certrificate of the RDP server does not mean that the certificate will be trusted. Certificate trust requires a signed certificate from a CA that is **trusted** by the client. This is not likely to be the case in most scenarios. If you want to do that, you are on your own.
+> **WARNING**: Cloning the certificate of the RDP server does not mean that the certificate will be trusted. Certificate trust requires a signed certificate from a CA that is **trusted** by the client. This is not likely to be the case in most scenarios. If you want to do that, you are on your own.
 
 ## Steps
 

--- a/docs/cert-extraction.md
+++ b/docs/cert-extraction.md
@@ -1,0 +1,36 @@
+# Extracting Windows Server Remote Desktop Certificate
+
+This procedure is useful when running honeypots to support CredSSP (using `--auth ssp`).
+It requires Administrative privileges on the target server and the use of Mimikatz, so it assumes that you are able to deactivate the Anti-Virus on the target server.
+
+
+> **WARNING**: Cloning the certrificate of the RDP server does not mean that the certificate will be trusted. Certificate trust requires a signed certificate from a CA that is **trusted** by the client. This is not likely to be the case in most scenarios. If you want to do that, you are on your own.
+
+## Steps
+
+1. Turn off AV so mimikatz doesn't get flagged. (Or use excluded directory)
+2. Download mimikatz latest release.
+3. Go to `Start > Run... > certlm.msc` (optional)
+4. Identify the valid certificate under `Remote Desktop > Certificates` and note the thumbprint (optional)
+5. Export the Remote Desktop certificates using Mimikatz:
+
+   ```
+   crypto::capi
+   privilege::debug
+   crypto::cng
+   crypto::certificates /systemstore:LOCAL_MACHINE /store:"Remote Desktop" /export
+   ```
+
+6. Convert public key to `.pem` using openssl:
+
+   ```
+   openssl x509 -inform DER -outform PEM -in pubkey.der -out pubkey.pem
+   ```
+
+7. Remove private key password (password for `.pfx` is "mimikatz")
+
+   ```
+   openssl pkcs12 -nodes -in privkey.pfx -out privkey.key
+   ```
+
+You can now run `pyrdp-mitm.py` by specifying `-k privkey.key -c pubkey.pem` and PyRDP will serve the same certificate as the server.

--- a/pyrdp/layer/segmentation.py
+++ b/pyrdp/layer/segmentation.py
@@ -13,7 +13,7 @@ from pyrdp.layer.layer import BaseLayer, LayerObserver
 
 
 class SegmentationObserver(LayerObserver):
-    def onUnknownHeader(self, header):
+    def onUnknownHeader(self, header, data: bytes):
         pass
 
 
@@ -63,7 +63,7 @@ class SegmentationLayer(BaseLayer):
                     layer = self.layers[header]
                 except KeyError:
                     if self.observer:
-                        self.observer.onUnknownHeader(header)
+                        self.observer.onUnknownHeader(header, data)
                         return
                     else:
                         raise

--- a/pyrdp/mitm/X224MITM.py
+++ b/pyrdp/mitm/X224MITM.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -71,8 +71,8 @@ class X224MITM:
         chosenProtocols = self.originalRequest.requestedProtocols
 
         if chosenProtocols is not None:
-            # Only SSL is implemented, so remove other protocol flags
-            chosenProtocols &= NegotiationProtocols.SSL
+            # Tell the server we only support the allowed authentication methods.
+            chosenProtocols = self.state.config.authMethods
 
         modifiedRequest = NegotiationRequestPDU(
             self.originalRequest.cookie,
@@ -99,8 +99,11 @@ class X224MITM:
         :param _: the connection confirm PDU
         """
 
-        # X224 Response
-        protocols = NegotiationProtocols.SSL if self.originalRequest.tlsSupported else NegotiationProtocols.NONE
+        # FIXME: In case the server picks anything other than what we support, PyRDP is
+        #        likely going to be unable to complete the handshake with the server.
+        #        This should not happen since we are intercepting and spoofing the NEG_REQ,
+        #        though.
+        # protocols = NegotiationProtocols.SSL if self.originalRequest.tlsSupported else NegotiationProtocols.NONE
 
         parser = NegotiationResponseParser()
         response = parser.parse(pdu.payload)
@@ -108,9 +111,12 @@ class X224MITM:
             self.log.info("The server failed the negotiation. Error: %(error)s", {"error": NegotiationFailureCode.getMessage(response.failureCode)})
             payload = pdu.payload
         else:
-            payload = parser.write(NegotiationResponsePDU(NegotiationType.TYPE_RDP_NEG_RSP, 0x00, protocols))
+            # payload = parser.write(NegotiationResponsePDU(NegotiationType.TYPE_RDP_NEG_RSP, 0x00, protocols))
+            payload = pdu.payload
         self.client.sendConnectionConfirm(payload, source=0x1234)
 
+        # FIXME: This should be done based on what authentication method the server selected, not on what
+        #        the client supports.
         if self.originalRequest.tlsSupported:
             self.startTLSCallback()
             self.state.useTLS = True

--- a/pyrdp/mitm/X224MITM.py
+++ b/pyrdp/mitm/X224MITM.py
@@ -111,8 +111,7 @@ class X224MITM:
             self.log.info("The server failed the negotiation. Error: %(error)s", {"error": NegotiationFailureCode.getMessage(response.failureCode)})
             payload = pdu.payload
         else:
-            # payload = parser.write(NegotiationResponsePDU(NegotiationType.TYPE_RDP_NEG_RSP, 0x00, protocols))
-            payload = pdu.payload
+            payload = parser.write(NegotiationResponsePDU(NegotiationType.TYPE_RDP_NEG_RSP, 0x00, response.selectedProtocols))
         self.client.sendConnectionConfirm(payload, source=0x1234)
 
         # FIXME: This should be done based on what authentication method the server selected, not on what

--- a/pyrdp/mitm/X224MITM.py
+++ b/pyrdp/mitm/X224MITM.py
@@ -72,7 +72,7 @@ class X224MITM:
 
         if chosenProtocols is not None:
             # Tell the server we only support the allowed authentication methods.
-            chosenProtocols = self.state.config.authMethods
+            chosenProtocols &= self.state.config.authMethods
 
         modifiedRequest = NegotiationRequestPDU(
             self.originalRequest.cookie,

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -7,6 +7,7 @@
 from pathlib import Path
 from typing import Optional
 from pyrdp.core import settings
+from pyrdp.enum import NegotiationProtocols
 
 
 class MITMConfig:
@@ -77,6 +78,8 @@ class MITMConfig:
 
         self.useGdi: bool = False
         """Whether to allow the client to use the GDI rendering pipeline extension."""
+
+        self.authMethods: NegotiationProtocols = NegotiationProtocols.SSL
 
     @property
     def replayDir(self) -> Path:

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -80,6 +80,7 @@ class MITMConfig:
         """Whether to allow the client to use the GDI rendering pipeline extension."""
 
         self.authMethods: NegotiationProtocols = NegotiationProtocols.SSL
+        """Specifies the list of authentication protocols that PyRDP accepts."""
 
     @property
     def replayDir(self) -> Path:


### PR DESCRIPTION
This pull request adds a `--auth` switch that allows to selectively enable the authentication mechanisms that PyRDP will allow through. For now these only include `tls` and `ssp` with some strict limitations for CredSSP.

It also finally documents how to extract the private key of RDP servers so that we can close #154 
Also resolves #134.

## Details

- Does not support the actual negotiation of CredSSP, which would require a lot of code and knowledge of the NTLM hash or the target's credentials.
- Does not support the [CredSSPY][0] attack that was just released.
- In order for the connection to be MITMed, it requires the private key of the server

In practice, this means that the only purpose of this feature is to allow honeypots to expose CredSSP. Note that usage of CredSSP means credential stuffing is not possible since a secret key is derived from the NTLM hash of the credentials.

[0]: https://github.com/croustibaie/CredSSPY/

## Future Work

This pull-request also paves the way towards supporting other authentication techniques such as Early User Authorization (EUA), but that is not yet implemented.