### PR TITLE
[WIP] Add basic support for parsing Dynamic Channels (drdynvc)

### DIFF
--- a/pyrdp/layer/rdp/virtual_channel/dynamic_channel.py
+++ b/pyrdp/layer/rdp/virtual_channel/dynamic_channel.py
@@ -13,5 +13,5 @@ class DynamicChannelLayer(Layer):
     Layer to receive and send DynamicChannel channel (drdynvc) packets.
     """
 
-    def __init__(self, parser = DynamicChannelParser()):
+    def __init__(self, parser: DynamicChannelParser):
         super().__init__(parser)

--- a/pyrdp/logging/StatCounter.py
+++ b/pyrdp/logging/StatCounter.py
@@ -111,6 +111,15 @@ class STAT:
     CLIPBOARD_PASTE = "clipboardPastes"
     # Number of times data has been pasted by either end
 
+    DYNAMIC_CHANNEL = "dynamicChannel"
+    # Number of Dynamic Virtual Channel PDUs coming from either end
+
+    DYNAMIC_CHANNEL_CLIENT = "dynamicChannelClient"
+    # Number of Dynamic Virtual Channel PDUs coming from the client
+
+    DYNAMIC_CHANNEL_SERVER = "dynamicChannelServer"
+    # Number of Dynamic Virtual Channel PDUs coming from the server
+
 
 class StatCounter:
     """

--- a/pyrdp/mitm/DynamicChannelMITM.py
+++ b/pyrdp/mitm/DynamicChannelMITM.py
@@ -1,0 +1,75 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2020-2020 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+import binascii
+from logging import LoggerAdapter
+from typing import Dict
+
+from pyrdp.core import Subject
+from pyrdp.layer.rdp.virtual_channel.dynamic_channel import DynamicChannelLayer
+from pyrdp.logging.StatCounter import STAT, StatCounter
+from pyrdp.mitm.state import RDPMITMState
+from pyrdp.pdu.rdp.virtual_channel.dynamic_channel import CreateRequestPDU, DataPDU, \
+    DynamicChannelPDU
+
+
+class DynamicChannelMITM(Subject):
+    """
+    MITM component for the dynamic virtual channels (drdynvc).
+    """
+
+    def __init__(self, client: DynamicChannelLayer, server: DynamicChannelLayer, log: LoggerAdapter,
+                 statCounter: StatCounter, state: RDPMITMState):
+        """
+        :param client: DynamicChannel layer for the client side
+        :param server: DynamicChannel layer for the server side
+        :param log: logger for this component
+        :param statCounter: Object to keep miscellaneous stats for the current connection
+        :param state: the state of the PyRDP MITM connection.
+        """
+        super().__init__()
+
+        self.client = client
+        self.server = server
+        self.state = state
+        self.log = log
+        self.statCounter = statCounter
+
+        self.channels: Dict[int, str] = {}
+
+        self.client.createObserver(
+            onPDUReceived=self.onClientPDUReceived,
+        )
+
+        self.server.createObserver(
+            onPDUReceived=self.onServerPDUReceived,
+        )
+
+    def onClientPDUReceived(self, pdu: DynamicChannelPDU):
+        self.statCounter.increment(STAT.DYNAMIC_CHANNEL_CLIENT, STAT.DYNAMIC_CHANNEL)
+        self.handlePDU(pdu, self.server)
+
+    def onServerPDUReceived(self, pdu: DynamicChannelPDU):
+        self.statCounter.increment(STAT.DYNAMIC_CHANNEL_SERVER, STAT.DEVICE_REDIRECTION)
+        self.handlePDU(pdu, self.client)
+
+    def handlePDU(self, pdu: DynamicChannelPDU, destination: DynamicChannelLayer):
+        """
+        Handle the logic for a PDU and send the PDU to its destination.
+        :param pdu: the PDU that was received
+        :param destination: the destination layer
+        """
+        if isinstance(pdu, CreateRequestPDU):
+            self.channels[pdu.channelId] = pdu.channelName
+            self.log.info("Dynamic virtual channel creation received: ID: %(channelId)d Name: %(channelName)s", {"channelId": pdu.channelId, "channelName": pdu.channelName})
+        elif isinstance(pdu, DataPDU):
+            if pdu.channelId not in self.channels:
+                self.log.error("Received a data PDU in an unkown channel: %(channelId)s", {"channelId": pdu.channelId})
+            else:
+                self.log.debug("Data PDU for channel %(channelName)s: %(data)s", {"data": binascii.hexlify(pdu.payload), "channelName": self.channels[pdu.channelId]})
+        else:
+            self.log.debug("Dynamic Channel PDU received: %(dynVcPdu)s", {"dynVcPdu": pdu})
+
+        destination.sendPDU(pdu)

--- a/pyrdp/parser/rdp/virtual_channel/dynamic_channel.py
+++ b/pyrdp/parser/rdp/virtual_channel/dynamic_channel.py
@@ -6,11 +6,12 @@
 
 from io import BytesIO
 
-from pyrdp.core import Uint16LE, Uint32LE, Uint8
+from pyrdp.core import Uint16LE, Uint8
 from pyrdp.enum.virtual_channel.dynamic_channel import CbId, DynamicChannelCommand
 from pyrdp.parser import Parser
 from pyrdp.pdu import PDU
-from pyrdp.pdu.rdp.virtual_channel.dynamic_channel import CreateRequestPDU, CreateResponsePDU, DynamicChannelPDU
+from pyrdp.pdu.rdp.virtual_channel.dynamic_channel import CreateRequestPDU, DataPDU, \
+    DynamicChannelPDU
 
 
 class DynamicChannelParser(Parser):
@@ -18,8 +19,40 @@ class DynamicChannelParser(Parser):
     Parser for the dynamic channel (drdynvc) packets.
     """
 
-    def __init__(self):
+    def __init__(self, isClient):
         super().__init__()
+        self.isClient = isClient
+
+        if self.isClient:
+            # Parsers and writers unique for client
+
+            self.parsers = {
+
+            }
+
+            self.writers = {
+                DynamicChannelCommand.CREATE: self.writeCreateRequest
+            }
+        else:
+            # Parsers and writers unique for server
+
+            self.parsers = {
+                DynamicChannelCommand.CREATE: self.parseCreateRequest
+            }
+
+            self.writers = {
+
+            }
+
+        # Parsers and writers for both client and server
+
+        self.parsers.update({
+            DynamicChannelCommand.DATA: self.parseData
+        })
+
+        self.writers.update({
+            DynamicChannelCommand.DATA: self.writeData
+        })
 
     def parse(self, data: bytes) -> PDU:
         stream = BytesIO(data)
@@ -27,16 +60,48 @@ class DynamicChannelParser(Parser):
         cbid = (header & 0b00000011)
         sp = (header & 0b00001100) >> 2
         cmd = (header & 0b11110000) >> 4
+        pdu = DynamicChannelPDU(cbid, sp, cmd, stream.read())
+        if cmd in self.parsers:
+            return self.parsers[cmd](pdu)
+        else:
+            return pdu
 
-        if cmd == DynamicChannelCommand.CREATE:
-            channelId = self.readChannelId(stream, cbid)
-            channelName = ""
+    def parseCreateRequest(self, pdu: DynamicChannelPDU) -> CreateRequestPDU:
+        """
+        https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/4448ba4d-9a72-429f-8b65-6f4ec44f2985
+        :param pdu: The PDU with the payload to decode.
+        """
+        stream = BytesIO(pdu.payload)
+        channelId = self.readChannelId(stream, pdu.cbid)
+        channelName = ""
+        char = stream.read(1).decode()
+        while char != "\x00":
+            channelName += char
             char = stream.read(1).decode()
-            while char != "\x00":
-                channelName += char
-                char = stream.read(1).decode()
-            return CreateRequestPDU(cbid, sp, channelId, channelName)
-        return DynamicChannelPDU(cbid, sp, cmd, stream.read())
+        return CreateRequestPDU(pdu.cbid, pdu.sp, channelId, channelName)
+
+    def writeCreateRequest(self, pdu: CreateRequestPDU, stream: BytesIO):
+        """
+        https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/4448ba4d-9a72-429f-8b65-6f4ec44f2985
+        """
+        self.writeChannelId(stream, pdu.cbid, pdu.channelId)
+        stream.write(pdu.channelName.encode() + b"\x00")
+
+    def parseData(self, pdu: DynamicChannelPDU) -> DataPDU:
+        """
+        https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/15b59886-db44-47f1-8da3-47c8fcd82803
+        """
+        stream = BytesIO(pdu.payload)
+        channelId = self.readChannelId(stream, pdu.cbid)
+        data = stream.read()
+        return DataPDU(pdu.cbid, pdu.sp, channelId, payload=data)
+
+    def writeData(self, pdu: DataPDU, stream: BytesIO):
+        """
+        https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/15b59886-db44-47f1-8da3-47c8fcd82803
+        """
+        self.writeChannelId(stream, pdu.cbid, pdu.channelId)
+        stream.write(pdu.payload)
 
     def write(self, pdu: DynamicChannelPDU) -> bytes:
         stream = BytesIO()
@@ -44,11 +109,11 @@ class DynamicChannelParser(Parser):
         header |= pdu.sp << 2
         header |= pdu.cmd << 4
         Uint8.pack(header, stream)
-        if isinstance(pdu, CreateResponsePDU):
-            self.writeChannelId(stream, pdu.cbid, pdu.channelId)
-            Uint32LE.pack(pdu.creationStatus, stream)
+        if pdu.cmd in self.writers:
+            self.writers[pdu.cmd](pdu, stream)
         else:
-            raise NotImplementedError()
+            stream.write(pdu.payload)
+
         return stream.getvalue()
 
     def readChannelId(self, stream: BytesIO, cbid: int):

--- a/pyrdp/pdu/rdp/virtual_channel/dynamic_channel.py
+++ b/pyrdp/pdu/rdp/virtual_channel/dynamic_channel.py
@@ -41,3 +41,13 @@ class CreateResponsePDU(DynamicChannelPDU):
         super().__init__(cbid, sp, DynamicChannelCommand.CREATE)
         self.channelId = channelId
         self.creationStatus = creationStatus
+
+
+class DataPDU(DynamicChannelPDU):
+    """
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/15b59886-db44-47f1-8da3-47c8fcd82803
+    """
+
+    def __init__(self, cbid, sp, channelId: int, payload: bytes):
+        super().__init__(cbid, sp, DynamicChannelCommand.DATA, payload=payload)
+        self.channelId = channelId


### PR DESCRIPTION
While working on a CTF challenge, I wanted to test some things with the dynamic channels (if you come across this PR in the context of said CTF, this PR will NOT help you solve the challenge), so I built a basic MITM object to interact with them.

For reference, dynamic channels ( https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/3bd53020-9b64-4c9a-97fc-90a79e7e1e06 ) is the "new and improved" way to extend RDP functions

Some examples of channels that were opened using win10 mstsc to another win10 machine:
![image](https://user-images.githubusercontent.com/14599855/84601884-7a8f0a00-ae51-11ea-9afc-4a163e01cceb.png)
![image](https://user-images.githubusercontent.com/14599855/84601889-84b10880-ae51-11ea-8596-ecd19617c7f1.png)
![image](https://user-images.githubusercontent.com/14599855/84601895-8b3f8000-ae51-11ea-957d-809b9dd4d211.png)
![image](https://user-images.githubusercontent.com/14599855/84601897-94305180-ae51-11ea-93e9-e1aa8e392551.png)

I'll leave this PR as a WIP because it has not been tested enough to go to production and the current logs do not bring a lot of values. However, if we ever plan to implement a sub-MITM for a specific dynamic channel, this might come in handy!
