### PR TITLE
Feature: Client-Only Transparent Proxy

### DIFF
--- a/docs/transparent-proxy.md
+++ b/docs/transparent-proxy.md
@@ -8,6 +8,19 @@ PyRDP is deployed. It is likely that the examples below will not work
 as-is and require modifications and testing during deployment.
 
 
+There are two base modes for transparent proxying:
+
+1. A single server is targeted and poisoned to reply to the MITM. The
+   MITM thus impersonates a single server and both clients and server
+   will not be aware of the proxy. This mode is useful for honeypots.
+   
+2. No server is targeted and the MITM will establish a direct
+   connection to the intended server. In this mode, the server will
+   see connections as coming from the MITM, but clients will not be
+   aware of the proxy. This mode is useful when ARP poisoning a subnet
+   during engagements.
+
+
 ## Basic L3 TPROXY
 
 This example is a simple Layer 3 proxy which intercepts RDP

--- a/pyrdp/mitm/AttackerMITM.py
+++ b/pyrdp/mitm/AttackerMITM.py
@@ -7,7 +7,9 @@ from collections import defaultdict
 from logging import LoggerAdapter
 from pathlib import Path
 from typing import Dict, Optional
+from functools import partial
 
+from pyrdp.core import AsyncIOSequencer
 from pyrdp.enum import FastPathInputType, FastPathOutputType, MouseButton, PlayerPDUType, PointerFlag, ScanCodeTuple
 from pyrdp.layer import FastPathLayer, PlayerLayer
 from pyrdp.mitm.DeviceRedirectionMITM import DeviceRedirectionMITM, DeviceRedirectionMITMObserver
@@ -96,10 +98,19 @@ class AttackerMITM(DeviceRedirectionMITMObserver):
             for key in keys:
                 self.handleKeyboard(PlayerKeyboardPDU(0, key.code, released, key.extended))
 
+
+    def sendOne(self, x, y):
+        self.handleText(PlayerTextPDU(0, x, y))
+        return 25
+
     def sendText(self, text: str):
+        seq = []
+
         for c in text:
             for released in [False, True]:
-                self.handleText(PlayerTextPDU(0, c, released))
+                seq.append(partial(self.sendOne, c, released))
+
+        return seq
 
 
     def handleMouseMove(self, pdu: PlayerMouseMovePDU):

--- a/pyrdp/mitm/AttackerMITM.py
+++ b/pyrdp/mitm/AttackerMITM.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Dict, Optional
 from functools import partial
 
-from pyrdp.core import AsyncIOSequencer
 from pyrdp.enum import FastPathInputType, FastPathOutputType, MouseButton, PlayerPDUType, PointerFlag, ScanCodeTuple
 from pyrdp.layer import FastPathLayer, PlayerLayer
 from pyrdp.mitm.DeviceRedirectionMITM import DeviceRedirectionMITM, DeviceRedirectionMITMObserver

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -191,7 +191,13 @@ class RDPMITM:
         serverFactory = AwaitableClientFactory(self.server.tcp)
         if self.config.transparent:
             src = self.client.tcp.transport.client
-            connectTransparent(self.config.targetHost, self.config.targetPort, serverFactory, bindAddress=(src[0], 0))
+            if self.config.targetHost:
+                # Fully Transparent (with a specific poisoned target.)
+                connectTransparent(self.config.targetHost, self.config.targetPort, serverFactory, bindAddress=(src[0], 0))
+            else:
+                # Half Transparent (for client-side only)
+                dst = self.client.tcp.transport.getHost().host
+                reactor.connectTCP(dst, self.config.targetPort, serverFactory)
         else:
             reactor.connectTCP(self.config.targetHost, self.config.targetPort, serverFactory)
 

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -216,7 +216,12 @@ def configure(cmdline=None) -> MITMConfig:
         sys.stderr.write('error: A relay target is required unless running in transparent proxy mode.\n')
         sys.exit(1)
 
-    targetHost, targetPort = parseTarget(args.target)
+    if args.target:
+        targetHost, targetPort = parseTarget(args.target)
+    else:
+        targetHost = None
+        targetPort = 3389  # FIXME: Allow to set transparent port as well.
+
     key, certificate = validateKeyAndCertificate(args.private_key, args.certificate)
 
     config = MITMConfig()

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -130,7 +130,7 @@ def showConfiguration(config: MITMConfig):
 
 def buildArgParser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("target", help="IP:port of the target RDP machine (ex: 192.168.1.10:3390)")
+    parser.add_argument("target", help="IP:port of the target RDP machine (ex: 192.168.1.10:3390)", nargs='?', default=None)
     parser.add_argument("-l", "--listen", help="Port number to listen on (default: 3389)", default=3389)
     parser.add_argument("-o", "--output", help="Output folder", default="pyrdp_output")
     parser.add_argument("-i", "--destination-ip",
@@ -210,6 +210,11 @@ def configure(cmdline=None) -> MITMConfig:
 
     configureLoggers(cfg)
     logger = logging.getLogger(LOGGER_NAMES.PYRDP)
+
+    if args.target is None and not args.transparent:
+        parser.print_usage()
+        sys.stderr.write('error: A relay target is required unless running in transparent proxy mode.\n')
+        sys.exit(1)
 
     targetHost, targetPort = parseTarget(args.target)
     key, certificate = validateKeyAndCertificate(args.private_key, args.certificate)


### PR DESCRIPTION
This pull request adds support for client-only transparent proxying (See `docs/transparent-proxy.md` for firewall setup) For scenarios where a subnet is to be spoofed (via ARP, for instance) but connections to the target server should be direct.

Caveats: It will fail noisily (impossible to connect) if the target servers have NLA enabled. Nothing we can do about this.

Also this includes some bug fixes:

- Fixes a timing issue where payloads (cmd or powershell) could be sent out-of-order due to all keystroke PDUs being queued in parallel.
- Fixes #203 so that it is possible to use `--payload` without having a player running.

Missing:
- [x] Release Notes
- [x] Maybe Documentation on Client-Only proxying?