### PR TITLE
Feature(#94) Add Dynamic Certificate Cloning Support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 === Enhancements
 
+* Added support for dynamic certificate cloning using `-c auto` ({uri-issue}94[#94])
 * Introduced the `pyrdp-convert` tool to convert between pcaps, PyRDP replay files and MP4 video files.
   Read link:README.md#using-pyrdp-convert[its section in the README for details].
   See {uri-issue}199[#199], {uri-issue}188[#188] and {uri-issue}170[#170].

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 === Enhancements
 
-* Added support for dynamic certificate cloning using `-c auto` ({uri-issue}94[#94])
+* Added support for dynamic certificate cloning when no certificate is specified. ({uri-issue}94[#94])
 * Introduced the `pyrdp-convert` tool to convert between pcaps, PyRDP replay files and MP4 video files.
   Read link:README.md#using-pyrdp-convert[its section in the README for details].
   See {uri-issue}199[#199], {uri-issue}188[#188] and {uri-issue}170[#170].

--- a/pyrdp/core/ssl.py
+++ b/pyrdp/core/ssl.py
@@ -1,23 +1,17 @@
 #
-# Copyright (c) 2014-2015 Sylvain Peyrefitte
+# Copyright (c) 2014-2020 Sylvain Peyrefitte
+# Copyright (c) 2020 GoSecure Inc.
 #
-# This file is part of rdpy.
+# This file is part of the PyRDP project.
 #
-# rdpy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# Licensed under the GPLv3 or later.
 #
 
+from os import path
+
+import OpenSSL
 from OpenSSL import SSL
+
 from twisted.internet import ssl
 
 
@@ -60,3 +54,56 @@ class ServerTLSContext(ssl.DefaultOpenSSLContextFactory):
         # See comment in ClientTLSContext
         ssl.DefaultOpenSSLContextFactory.__init__(self, privateKeyFileName, certificateFileName, SSL.SSLv23_METHOD,
                                                   TPDUSSLContext)
+
+
+class CertificateCache():
+    """
+    Handle multiple certificates.
+    """
+
+    def __init__(self, cachedir):
+        self._root = cachedir
+
+    def clone(self, cert: OpenSSL.crypto.X509) -> (OpenSSL.crypto.PKey, OpenSSL.crypto.X509):
+        """Clone the provided certificate."""
+
+        # Generate a private key for the server.
+        key = OpenSSL.crypto.PKey()
+        key.generate_key(OpenSSL.crypto.TYPE_RSA, cert.get_pubkey().bits())
+
+        # Actual type is str, but this prevents warnings
+        digestAlgorithm: bytes = cert.get_signature_algorithm().decode()
+
+        # Force digest algorithm to be sha256
+        if digestAlgorithm in ["md4", "md5"]:
+            digestAlgorithm = "sha256"
+
+        cert.set_pubkey(key)
+        cert.sign(key, digestAlgorithm)
+
+        return key, cert
+
+    def lookup(self, cert: OpenSSL.crypto.X509) -> (str, str):
+        subject = cert.get_subject()
+        parts = dict(subject.get_components())
+        commonName = parts[b'CN'].decode()
+        base = str(self._root / commonName)
+
+        if path.exists(base + '.pem'):
+            # Recover cache entry from disk.
+            privKey = base + '.pem'
+            certFile = base + '.crt'
+            return privKey, certFile
+        else:
+            priv, cert = self.clone(cert)
+            privKey = base + '.pem'
+            certFile = base + '.crt'
+
+            # Save Certificate to disk
+            with open(certFile, "wb") as f:
+                f.write(OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, cert))
+
+            with open(privKey, "wb") as f:
+                f.write(OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, priv))
+
+            return privKey, certFile

--- a/pyrdp/core/ssl.py
+++ b/pyrdp/core/ssl.py
@@ -61,8 +61,9 @@ class CertificateCache():
     Handle multiple certificates.
     """
 
-    def __init__(self, cachedir):
+    def __init__(self, cachedir, log):
         self._root = cachedir
+        self.log = log
 
     def clone(self, cert: OpenSSL.crypto.X509) -> (OpenSSL.crypto.PKey, OpenSSL.crypto.X509):
         """Clone the provided certificate."""
@@ -90,6 +91,8 @@ class CertificateCache():
         base = str(self._root / commonName)
 
         if path.exists(base + '.pem'):
+            self.log.info('Using cached certificate for %s', commonName)
+
             # Recover cache entry from disk.
             privKey = base + '.pem'
             certFile = base + '.crt'
@@ -105,5 +108,7 @@ class CertificateCache():
 
             with open(privKey, "wb") as f:
                 f.write(OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, priv))
+
+            self.log.info('Cloned server certificate to %s', certFile)
 
             return privKey, certFile

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -139,8 +139,9 @@ class RDPMITM:
         self.player.player.addObserver(LayerLogger(self.attackerLog))
 
         self.ensureOutDir()
-        if config.certificateFileName == "auto":
-            self.certs: CertificateCache = CertificateCache(self.config.certDir)
+
+        if config.certificateFileName is None:
+            self.certs: CertificateCache = CertificateCache(self.config.certDir, mainLogger.createChild("cert"))
         else:
             self.certs = None
 

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -1,11 +1,12 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019-2020 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 import asyncio
 import datetime
+import typing
 
 from twisted.internet import reactor
 from twisted.internet.protocol import Protocol
@@ -137,9 +138,11 @@ class RDPMITM:
 
         self.player.player.addObserver(LayerLogger(self.attackerLog))
 
-        self.config.outDir.mkdir(parents=True, exist_ok=True)
-        self.config.replayDir.mkdir(exist_ok=True)
-        self.config.fileDir.mkdir(exist_ok=True)
+        self.ensureOutDir()
+        # if config.certificateFileName == "auto":
+        #     self.certCache: CertificateCache = CertificateCache(self.config.certDir)
+        # else:
+        #     self.certCache = None
 
         self.state.securitySettings.addObserver(RC4LoggingObserver(self.rc4Log))
 
@@ -213,17 +216,40 @@ class RDPMITM:
             except asyncio.TimeoutError:
                 self.log.error("Failed to connect to recording host: timeout expired")
 
-    def startTLS(self):
+    def doClientTls(self):
+        cert = self.server.tcp.transport.getPeerCertificate()
+        if not cert:
+            # Wait for server certificate
+            reactor.callLater(1, self.doClientTls)
+
+        # Clone certificate if necessary.
+        if self.certs:
+            contextForClient = ServerTLSContext(self.config.privateKeyFileName, self.config.certificateFileName)
+        else:
+            # No automated certificate cloning. Use the specified certificate.
+            contextForClient = ServerTLSContext(self.config.privateKeyFileName, self.config.certificateFileName)
+
+        # Establish TLS tunnel with the client
+        self.onTlsReady()
+        self.client.tcp.startTLS(contextForClient)
+        self.onTlsReady = None
+
+        # Add unknown packet handlers.
+        self.client.segmentation.addObserver(PacketForwarder(self.server.tcp))
+        self.server.segmentation.addObserver(PacketForwarder(self.client.tcp))
+
+    def startTLS(self, onTlsReady: typing.Callable[[], None]):
         """
         Execute a startTLS on both the client and server side.
         """
-        contextForClient = ServerTLSContext(self.config.privateKeyFileName, self.config.certificateFileName)
-        contextForServer = ClientTLSContext()
+        self.onTlsReady = onTlsReady
 
-        self.client.tcp.startTLS(contextForClient)
+        # Establish TLS tunnel with target server...
+        contextForServer = ClientTLSContext()
         self.server.tcp.startTLS(contextForServer)
-        self.client.segmentation.addObserver(PacketForwarder(self.server.tcp))
-        self.server.segmentation.addObserver(PacketForwarder(self.client.tcp))
+
+        # Establish TLS tunnel with client.
+        reactor.callLater(1, self.doClientTls)
 
     def buildChannel(self, client: MCSServerChannel, server: MCSClientChannel):
         """
@@ -420,3 +446,9 @@ class RDPMITM:
             enableForwarding
         ])
         sequencer.run()
+
+    def ensureOutDir(self):
+        self.config.outDir.mkdir(parents=True, exist_ok=True)
+        self.config.replayDir.mkdir(exist_ok=True)
+        self.config.fileDir.mkdir(exist_ok=True)
+        self.config.certDir.mkdir(exist_ok=True)

--- a/pyrdp/mitm/cli.py
+++ b/pyrdp/mitm/cli.py
@@ -40,7 +40,9 @@ def parseTarget(target: str) -> Tuple[str, int]:
 
 
 def validateKeyAndCertificate(private_key: str, certificate: str) -> Tuple[str, str]:
-    if (private_key is None) != (certificate is None):
+    if 'auto' in [certificate, private_key]:
+        return 'auto', 'auto'  # Use dynamic certificate generation
+    elif (private_key is None) != (certificate is None):
         sys.stderr.write("You must provide both the private key and the certificate")
         sys.exit(1)
     elif private_key is None:
@@ -139,7 +141,7 @@ def buildArgParser():
     parser.add_argument("-d", "--destination-port",
                         help="Listening port of the PyRDP player (default: 3000).", default=3000)
     parser.add_argument("-k", "--private-key", help="Path to private key (for SSL)")
-    parser.add_argument("-c", "--certificate", help="Path to certificate (for SSL)")
+    parser.add_argument("-c", "--certificate", help="Path to certificate (for SSL). 'auto' for dynamic generation")
     parser.add_argument("-u", "--username", help="Username that will replace the client's username", default=None)
     parser.add_argument("-p", "--password", help="Password that will replace the client's password", default=None)
     parser.add_argument("-L", "--log-level", help="Console logging level. Logs saved to file are always verbose.",

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -96,6 +96,13 @@ class MITMConfig:
         """
         return self.outDir / "files"
 
+    @property
+    def certDir(self) -> Path:
+        """
+        Get the directory for dynamically generated certificates.
+        """
+        return self.outDir / "certs"
+
 
 """
 The default MITM configuration.


### PR DESCRIPTION
This pull request re-orders the StartTLS negotiation code and adds a certificate cache that clones and stores all encountered certificates from target servers.

The cache is persisted on disk in `$PYRDP_OUTDIR/certs`.

Dynamic certificate cloning can be enabled with `-c auto`, otherwise the default (or specified) certificate is used as usual.


-----
Closes #94 