### PR TITLE
GitHub Actions: added more smoke testing in docker task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,20 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Docker image
       run: docker build -t pyrdp .
-    - name: Smoke test docker image
+    - name: "Smoke test docker image: pyrdp-convert.py"
+      run: docker run pyrdp pyrdp-convert.py -h
+    - name: "Smoke test docker image: pyrdp-player.py"
       run: docker run pyrdp pyrdp-player.py -h
+    - name: "Smoke test docker image: pyrdp-mitm.py"
+      run: docker run pyrdp pyrdp-mitm.py -h
     - name: Build slim Docker image
       run: docker build -f Dockerfile.slim -t pyrdp .
-    - name: Smoke test docker slim image
+    # disabled until we fix #252
+    #- name: "Smoke test docker image: pyrdp-convert.py"
+    #  run: docker run pyrdp pyrdp-convert.py -h
+    - name: "Smoke test docker image: pyrdp-player.py"
+      run: docker run pyrdp pyrdp-player.py -h
+    - name: "Smoke test docker image: pyrdp-mitm.py"
       run: docker run pyrdp pyrdp-mitm.py -h
 
   install-and-test-ubuntu:


### PR DESCRIPTION
This should fail because of #250. Let's see.