### PR TITLE
Increase robustness of converting PCAPs with unhandled data

### DIFF
--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -95,10 +95,13 @@ class RDPReplayer(RDPMITM):
         pass
 
     def recv(self, data: bytes, from_client: bool):
-        if from_client:
-            self.client.tcp.dataReceived(data)
-        else:
-            self.server.tcp.dataReceived(data)
+        try:
+            if from_client:
+                self.client.tcp.dataReceived(data)
+            else:
+                self.server.tcp.dataReceived(data)
+        except Exception as e:
+            print(f'\n[-] Failed to handle data, continuing anyway: {e}')
 
     def setTimeStamp(self, timeStamp: float):
         self.recorder.setTimeStamp(int(timeStamp))


### PR DESCRIPTION
When converting a *real* RDP session with pyrdp-convert it frequently fails to process PDUs with unhandled data. This is to be expected. If the exception is handled then conversion can generally continue without error producing a valid pyrdp output file.

