### PR TITLE
fix: bad logic for handling unsupported virtual channels

### DIFF
--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -261,18 +261,18 @@ class RDPMITM:
         :param server: MCS channel for the server side
         """
 
-        userID = client.userID
         channelID = client.channelID
 
-        if userID == channelID:
+        if channelID not in self.state.channelMap:
             self.buildVirtualChannel(client, server)
-        elif channelID in self.state.channelMap:
-            if self.state.channelMap[channelID] == MCSChannelName.IO:
-                self.buildIOChannel(client, server)
-            elif self.state.channelMap[channelID] == MCSChannelName.CLIPBOARD:
-                self.buildClipboardChannel(client, server)
-            elif self.state.channelMap[channelID] == MCSChannelName.DEVICE_REDIRECTION:
-                self.buildDeviceChannel(client, server)
+            return
+
+        if self.state.channelMap[channelID] == MCSChannelName.IO:
+            self.buildIOChannel(client, server)
+        elif self.state.channelMap[channelID] == MCSChannelName.CLIPBOARD:
+            self.buildClipboardChannel(client, server)
+        elif self.state.channelMap[channelID] == MCSChannelName.DEVICE_REDIRECTION:
+            self.buildDeviceChannel(client, server)
         else:
             self.buildVirtualChannel(client, server)
 


### PR DESCRIPTION
This is a PR following up #246 for the RDPDR delay that I noticed during regression testing.

The problem was flawed logic that would not create generic virtual channels when the channels were in the map but didn't have specific PyRDP parsers tied to them.