### PR TITLE
File naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         working-directory: ./
         run: coverage run --append -m unittest discover -v
 
-      - name: Coverage
+      - name: Coverage report
         working-directory: ./
         run: coverage report --fail-under=40
 
@@ -108,6 +108,9 @@ jobs:
       - name: Install PyRDP
         working-directory: .
         run: pip install -U -e .[full]
+      - name: Install coverage
+        working-directory: .
+        run: pip install coverage
 
       - name: Extract test files
         uses: DuckSoft/extract-7z-action@v1.0
@@ -117,16 +120,20 @@ jobs:
 
       - name: Integration Test with a prerecorded PCAP.
         working-directory: ./
-        run: python test/test_prerecorded.py
+        run: coverage run test/test_prerecorded.py
 
       - name: pyrdp-mitm.py initialization test
         working-directory: ./
-        run: python test/test_mitm_initialization.py dummy_value
+        run: coverage run --append test/test_mitm_initialization.py dummy_value
 
       - name: pyrdp-player.py read a replay in headless mode test
         working-directory: ./
-        run: python bin/pyrdp-player.py --headless test/files/test_session.replay
+        run: coverage run --append bin/pyrdp-player.py --headless test/files/test_session.replay
 
       - name: Run unit tests
         working-directory: ./
         run: coverage run --append -m unittest discover -v
+
+      - name: Coverage report
+        working-directory: ./
+        run: coverage report --fail-under=40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,52 +35,56 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.7' # Version range or exact version of a Python version to use, using semvers version range syntax.
-        architecture: 'x64'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7' # Version range or exact version of a Python version to use, using semvers version range syntax.
+          architecture: 'x64'
 
-    - name: Python version
-      run: python --version
-    - name: Pip version
-      run: pip --version
+      - name: Python version
+        run: python --version
+      - name: Pip version
+        run: pip --version
 
-    - name: Install setuptools
-      run: sudo apt install python3-setuptools
-    - name: Install PyRDP dependencies
-      run: sudo apt install libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx git python3-dev
-    - name: Install wheel
-      working-directory: .
-      run: pip install wheel
-    - name: Install PyRDP
-      working-directory: .
-      run: pip install -U -e .[full]
+      - name: Install setuptools
+        run: sudo apt install python3-setuptools
+      - name: Install PyRDP dependencies
+        run: sudo apt install libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx git python3-dev
+      - name: Install wheel
+        working-directory: .
+        run: pip install wheel
+      - name: Install PyRDP
+        working-directory: .
+        run: pip install -U -e .[full]
 
-    - name: Install ci dependencies
-      run: pip install -r requirements-ci.txt
+      - name: Install ci dependencies
+        run: pip install -r requirements-ci.txt
 
-    - name: Extract test files
-      uses: DuckSoft/extract-7z-action@v1.0
-      with:
-        pathSource: test/files/test_files.zip
-        pathTarget: test/files
+      - name: Extract test files
+        uses: DuckSoft/extract-7z-action@v1.0
+        with:
+          pathSource: test/files/test_files.zip
+          pathTarget: test/files
 
-    - name: Integration Test with a prerecorded PCAP.
-      working-directory: ./
-      run: coverage run test/test_prerecorded.py
+      - name: Integration Test with a prerecorded PCAP.
+        working-directory: ./
+        run: coverage run test/test_prerecorded.py
 
-    - name: pyrdp-mitm.py initialization integration test
-      working-directory: ./
-      run: coverage run --append test/test_mitm_initialization.py dummy_value
+      - name: pyrdp-mitm.py initialization integration test
+        working-directory: ./
+        run: coverage run --append test/test_mitm_initialization.py dummy_value
 
-    - name: pyrdp-player.py read a replay in headless mode test
-      working-directory: ./
-      run: coverage run --append bin/pyrdp-player.py --headless test/files/test_session.replay
+      - name: pyrdp-player.py read a replay in headless mode test
+        working-directory: ./
+        run: coverage run --append bin/pyrdp-player.py --headless test/files/test_session.replay
 
-    - name: Coverage
-      working-directory: ./
-      run: coverage report --fail-under=40
+      - name: Run unit tests
+        working-directory: ./
+        run: coverage run --append -m unittest discover -v
+
+      - name: Coverage
+        working-directory: ./
+        run: coverage report --fail-under=40
 
 
 
@@ -122,3 +126,7 @@ jobs:
       - name: pyrdp-player.py read a replay in headless mode test
         working-directory: ./
         run: python bin/pyrdp-player.py --headless test/files/test_session.replay
+
+      - name: Run unit tests
+        working-directory: ./
+        run: coverage run --append -m unittest discover -v

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ mitm.json
 
 # twisted
 /twisted/plugins/dropin.cache
+
+# code coverage
+htmlcov/

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -122,7 +122,7 @@ class RDPReplayer(RDPMITM):
         # We'll set up the recorder ourselves
         config.recordReplays = False
 
-        state = RDPMITMState(config)
+        state = RDPMITMState(config, log.sessionID)
 
         sink, outfile = getSink(format, output_path)
         transport = ConversionLayer(sink) if sink else FileLayer(outfile)

--- a/pyrdp/mitm/ClipboardMITM.py
+++ b/pyrdp/mitm/ClipboardMITM.py
@@ -14,6 +14,7 @@ from pyrdp.core import decodeUTF16LE, Uint64LE
 from pyrdp.enum import ClipboardFormatNumber, ClipboardMessageFlags, ClipboardMessageType, PlayerPDUType, FileContentsFlags
 from pyrdp.layer import ClipboardLayer
 from pyrdp.logging.StatCounter import StatCounter, STAT
+from pyrdp.mitm.state import RDPMITMState
 from pyrdp.pdu import ClipboardPDU, FormatDataRequestPDU, FormatDataResponsePDU, FileContentsRequestPDU, FileContentsResponsePDU
 from pyrdp.parser.rdp.virtual_channel.clipboard import FileDescriptor
 from pyrdp.recording import Recorder
@@ -32,7 +33,7 @@ class PassiveClipboardStealer:
     """
 
     def __init__(self, config: MITMConfig, client: ClipboardLayer, server: ClipboardLayer, log: LoggerAdapter, recorder: Recorder,
-                 statCounter: StatCounter):
+                 statCounter: StatCounter, state: RDPMITMState):
         """
         :param client: clipboard layer for the client side
         :param server: clipboard layer for the server side
@@ -44,13 +45,14 @@ class PassiveClipboardStealer:
         self.server = server
         self.config = config
         self.log = log
+        self.state = state
         self.recorder = recorder
         self.forwardNextDataResponse = True
         self.files = []
         self.transfers = {}
         self.timeouts = {}  # Track active timeout monitoring tasks.
 
-        self.fileDir = f"{self.config.fileDir}/{self.log.sessionID}"
+        self.fileDir = f"{self.config.fileDir}/{self.state.sessionID}"
 
         self.client.createObserver(
             onPDUReceived = self.onClientPDUReceived,
@@ -206,8 +208,8 @@ class ActiveClipboardStealer(PassiveClipboardStealer):
     """
 
     def __init__(self, config: MITMConfig, client: ClipboardLayer, server: ClipboardLayer, log: LoggerAdapter, recorder: Recorder,
-                 statCounter: StatCounter):
-        super().__init__(config, client, server, log, recorder, statCounter)
+                 statCounter: StatCounter, state: RDPMITMState):
+        super().__init__(config, client, server, log, recorder, statCounter, state)
 
     def handlePDU(self, pdu: ClipboardPDU, destination: ClipboardLayer):
         """

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -217,7 +217,7 @@ class DeviceRedirectionMITM(Subject):
             mapping = FileMapping.generate(remotePath, self.config.fileDir)
             proxy = FileProxy(mapping.localPath, "wb")
 
-            key = (response.deviceID, response.completionID, response.fileID)
+            key = (response.deviceID, response.fileID)
             self.openedFiles[key] = proxy
             self.openedMappings[key] = mapping
 
@@ -234,7 +234,7 @@ class DeviceRedirectionMITM(Subject):
         :param request: the device read request
         :param response: the device IO response to the request
         """
-        key = (response.deviceID, response.completionID, request.fileID)
+        key = (response.deviceID, request.fileID)
 
         if key in self.openedFiles:
             file = self.openedFiles[key]
@@ -258,7 +258,7 @@ class DeviceRedirectionMITM(Subject):
         """
 
         self.statCounter.increment(STAT.DEVICE_REDIRECTION_FILE_CLOSE)
-        key = (response.deviceID, response.completionID, request.fileID)
+        key = (response.deviceID, request.fileID)
 
         if key in self.openedFiles:
             file = self.openedFiles.pop(key)

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -135,7 +135,7 @@ class DeviceRedirectionMITM(Subject):
         if isinstance(pdu, DeviceIORequestPDU) and destination is self.client:
             self.handleIORequest(pdu)
         elif isinstance(pdu, DeviceIOResponsePDU) and destination is self.server:
-            dropPDU = pdu.completionID in self.forgedRequests
+            dropPDU = (pdu.deviceID, pdu.completionID) in self.forgedRequests
             self.handleIOResponse(pdu)
 
         elif isinstance(pdu, DeviceListAnnounceRequest):

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -526,7 +526,7 @@ class DeviceRedirectionMITM(Subject):
                 openPath = self.path[: self.path.index("*")]
 
             if openPath.endswith("\\"):
-                openPath = self.path[: -1]
+                openPath = openPath[: -1]
 
             # We need to start by opening the directory.
             request = DeviceCreateRequestPDU(

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -328,7 +328,7 @@ class DeviceRedirectionMITM(Subject):
         """
         completionID = DeviceRedirectionMITM.FORGED_COMPLETION_ID
 
-        while completionID in self.forgedRequests:
+        while completionID in [key[1] for key in self.forgedRequests]:
             completionID += 1
 
         return completionID

--- a/pyrdp/mitm/DeviceRedirectionMITM.py
+++ b/pyrdp/mitm/DeviceRedirectionMITM.py
@@ -283,15 +283,25 @@ class DeviceRedirectionMITM(Subject):
 
                 currentMapping.hash = sha1.hexdigest()
 
+            isDuplicate = False
+
             # Check if a file with the same hash exists. If so, keep that one and remove the current file.
-            for localPath, mapping in self.fileMap.items():
+            for _, mapping in self.fileMap.items():
                 if mapping is currentMapping:
                     continue
 
                 if mapping.hash == currentMapping.hash:
-                    currentMapping.localPath.unlink()
-                    self.fileMap.pop(currentMapping.localPath.name)
+                    isDuplicate = True
                     break
+
+            if isDuplicate:
+                currentMapping.localPath.unlink()
+                self.fileMap.pop(currentMapping.localPath.name)
+            else:
+                oldName = currentMapping.localPath.name
+                currentMapping.renameToHash()
+                self.fileMap.pop(oldName)
+                self.fileMap[currentMapping.localPath.name] = currentMapping
 
             self.saveMapping()
 

--- a/pyrdp/mitm/FileCrawlerMITM.py
+++ b/pyrdp/mitm/FileCrawlerMITM.py
@@ -216,7 +216,7 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
 
     def downloadFile(self, file: VirtualFile):
         remotePath = file.path
-        basePath = f"{self.config.fileDir}/{self.log.sessionID}"
+        basePath = f"{self.config.fileDir}/{self.state.sessionID}"
         localPath = f"{basePath}{remotePath}"
 
         self.log.info("Saving %(remotePath)s to %(localPath)s", {"remotePath": remotePath, "localPath": localPath})

--- a/pyrdp/mitm/FileCrawlerMITM.py
+++ b/pyrdp/mitm/FileCrawlerMITM.py
@@ -126,7 +126,7 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
         try:
             with open(path, "r") as f:
                 for line in f:
-                    if line and line[0] in ["#", " ", "\n"]:
+                    if not line or line[0] in ["#", " ", "\n"]:
                         continue
 
                     patternList.append(line.lower().rstrip())

--- a/pyrdp/mitm/FileCrawlerMITM.py
+++ b/pyrdp/mitm/FileCrawlerMITM.py
@@ -3,18 +3,19 @@
 # Copyright (C) 2019 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
+import fnmatch
 from collections import defaultdict
 from logging import LoggerAdapter
 from pathlib import Path
-from typing import BinaryIO, Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from pyrdp.enum.virtual_channel.device_redirection import DeviceType
-from pyrdp.mitm.config import MITMConfig
 from pyrdp.mitm.DeviceRedirectionMITM import DeviceRedirectionMITM, DeviceRedirectionMITMObserver
+from pyrdp.mitm.FileMapping import FileMapping
+from pyrdp.mitm.config import MITMConfig
 from pyrdp.mitm.state import RDPMITMState
 from pyrdp.pdu import DeviceAnnounce
 
-import fnmatch
 
 class VirtualFile:
     """
@@ -61,12 +62,11 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
         self.deviceRedirection: Optional[DeviceRedirectionMITM] = None
 
         # Pending crawler requests
-        self.fileDownloadRequests: Dict[int, Path] = {}
         self.directoryListingRequests: Dict[int, Path] = {}
         self.directoryListingLists = defaultdict(list)
 
         # Download management
-        self.downloadFiles: Dict[str, BinaryIO] = {}
+        self.fileMappings: Dict[str, FileMapping] = {}
         self.downloadDirectories: Set[int] = set()
 
         # Crawler detection patterns
@@ -101,9 +101,6 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
         Should only be called once.
         """
 
-        matchPath = None
-        ignorePath = None
-
         # Get the default file in pyrdp/mitm/crawler_config
         if self.config.crawlerMatchFileName:
             matchPath = Path(self.config.crawlerMatchFileName).absolute()
@@ -136,10 +133,22 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
 
         return patternList
 
+    def onDeviceAnnounce(self, device: DeviceAnnounce):
+        if device.deviceType == DeviceType.RDPDR_DTYP_FILESYSTEM:
+
+            drive = VirtualFile(device.deviceID, device.preferredDOSName, "/", True)
+
+            self.devices[drive.deviceID] = drive
+            self.unvisitedDrive.append(drive)
+
+            # If the crawler hasn't started, start one instance
+            if len(self.devices) == 1:
+                self.dispatchDownload()
+
     def dispatchDownload(self):
         """
         Processes each queue in order of priority.
-        File download have priority over directory download.
+        File downloads have priority over directory downloads.
         Crawl each folder before visiting another drive.
         """
 
@@ -161,14 +170,55 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
         # List an unvisited drive
         elif len(self.unvisitedDrive) != 0:
             drive = self.unvisitedDrive.pop()
-
-            # TODO : Maybe dump whole drive if there isn't a lot of files?
-            # Maybe if theres no directory at the root directory -> dump all?
             self.log.info("Begin crawling disk %(disk)s", {"disk" : drive.name})
             self.fileLogger.info("Begin crawling disk %(disk)s", {"disk" : drive.name})
             self.listDirectory(drive.deviceID, drive.path)
         else:
             self.log.info("Done crawling.")
+
+    def listDirectory(self, deviceID: int, path: str, download: bool = False):
+        """
+        List the directory
+        :param deviceID: Drive we are actually listing.
+        :param path: Path of the directory we are listing.
+        :param download: Wether or not we need to download this directory.
+        """
+        listingPath = str(Path(path).absolute()).replace("/", "\\")
+
+        if not listingPath.endswith("*"):
+            if not listingPath.endswith("\\"):
+                listingPath += "\\"
+
+            listingPath += "*"
+
+        requestID = self.deviceRedirection.sendForgedDirectoryListing(deviceID, listingPath)
+
+        # If the directory is flagged for download, keep trace of the incoming request to trigger download.
+        if download:
+            self.downloadDirectories.add(requestID)
+
+        self.directoryListingRequests[requestID] = Path(path).absolute()
+
+    def onDirectoryListingResult(self, deviceID: int, requestID: int, fileName: str, isDirectory: bool):
+        if requestID not in self.directoryListingRequests:
+            return
+
+        path = self.directoryListingRequests[requestID]
+        filePath = path / fileName
+
+        file = VirtualFile(deviceID, fileName, str(filePath), isDirectory)
+        directoryList = self.directoryListingLists[requestID]
+        directoryList.append(file)
+
+    def onDirectoryListingComplete(self, deviceID: int, requestID: int):
+        self.directoryListingRequests.pop(requestID, {})
+
+        # If directory was flagged for download
+        if requestID in self.downloadDirectories:
+            self.downloadDirectories.remove(requestID)
+            self.addListingToDownloadQueue(requestID)
+        else:
+            self.crawlListing(requestID)
 
     def addListingToDownloadQueue(self, requestID: int):
         directoryList = self.directoryListingLists.pop(requestID, {})
@@ -181,6 +231,7 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
                 self.matchedDirectoryQueue.append(item)
             else:
                 self.matchedFileQueue.append(item)
+
         self.dispatchDownload()
 
     def crawlListing(self, requestID: int):
@@ -211,74 +262,34 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
                 if matched:
                     self.matchedFileQueue.append(item)
 
-            self.fileLogger.info("%(file)s - %(isDirectory)s - %(isDownloaded)s", {"file" : item.path, "isDirectory": item.isDirectory, "isDownloaded": matched})
+            self.fileLogger.info("%(file)s - %(isDirectory)s - %(isMatched)s", {
+                "file" : item.path,
+                "isDirectory": item.isDirectory,
+                "isMatched": matched
+            })
+
         self.dispatchDownload()
 
     def downloadFile(self, file: VirtualFile):
         remotePath = file.path
-        basePath = f"{self.config.fileDir}/{self.state.sessionID}"
-        localPath = f"{basePath}{remotePath}"
+        mapping = FileMapping.generate(
+            remotePath,
+            self.config.fileDir,
+            self.deviceRedirection.createDeviceRoot(file.deviceID),
+            self.log
+        )
 
-        self.log.info("Saving %(remotePath)s to %(localPath)s", {"remotePath": remotePath, "localPath": localPath})
-
-        try:
-            # Create parent directory, don't raise error if it already exists
-            Path(localPath).parent.mkdir(parents=True, exist_ok=True)
-            targetFile = open(localPath, "wb")
-        except Exception as e:
-            self.log.exception(e)
-            self.log.error("Cannot save file: %(localPath)s", {"localPath": localPath})
-            return
-
-        self.downloadFiles[remotePath] = targetFile
+        self.fileMappings[remotePath] = mapping
         self.deviceRedirection.sendForgedFileRead(file.deviceID, remotePath)
 
-    def listDirectory(self, deviceID: int, path: str, download: bool = False):
-        """
-        List the directory
-        :param deviceID: Drive we are actually listing.
-        :param path: Path of the directory we are listing.
-        :param download: Wether or not we need to download this directory.
-        """
-        listingPath = str(Path(path).absolute()).replace("/", "\\")
-
-        if not listingPath.endswith("*"):
-            if not listingPath.endswith("\\"):
-                listingPath += "\\"
-
-            listingPath += "*"
-
-        requestID = self.deviceRedirection.sendForgedDirectoryListing(deviceID, listingPath)
-
-        # If the directory is flagged for download, keep trace of the incoming request to trigger download.
-        if download:
-            self.downloadDirectories.add(requestID)
-
-        self.directoryListingRequests[requestID] = Path(path).absolute()
-
-    def onDeviceAnnounce(self, device: DeviceAnnounce):
-        if device.deviceType == DeviceType.RDPDR_DTYP_FILESYSTEM:
-
-            drive = VirtualFile(device.deviceID, device.preferredDOSName, "/", True)
-
-            self.devices[drive.deviceID] = drive
-            self.unvisitedDrive.append(drive)
-
-            # If the crawler hasn't started, start one instance
-            if len(self.devices) == 1:
-                self.dispatchDownload()
-
     def onFileDownloadResult(self, deviceID: int, requestID: int, path: str, offset: int, data: bytes):
-        remotePath = path.replace("\\", "/")
-
-        targetFile = self.downloadFiles[remotePath]
-        targetFile.write(data)
+        mapping = self.fileMappings[path]
+        mapping.seek(offset)
+        mapping.write(data)
 
     def onFileDownloadComplete(self, deviceID: int, requestID: int, path: str, errorCode: int):
-        remotePath = path.replace("\\", "/")
-
-        file = self.downloadFiles.pop(remotePath)
-        file.close()
+        mapping = self.fileMappings.pop(path)
+        mapping.finalize()
 
         if errorCode != 0:
             # TODO : Handle common error codes like :
@@ -286,29 +297,8 @@ class FileCrawlerMITM(DeviceRedirectionMITMObserver):
             # Doc : https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/18d8fbe8-a967-4f1c-ae50-99ca8e491d2d
 
             self.log.error("Error happened when downloading %(remotePath)s. The file may not have been saved completely. Error code: %(errorCode)s", {
-                "remotePath": remotePath,
+                "remotePath": path,
                 "errorCode": "0x%08lx" % errorCode,
             })
 
         self.dispatchDownload()
-
-    def onDirectoryListingResult(self, deviceID: int, requestID: int, fileName: str, isDirectory: bool):
-        if requestID not in self.directoryListingRequests:
-            return
-
-        path = self.directoryListingRequests[requestID]
-        filePath = path / fileName
-
-        file = VirtualFile(deviceID, fileName, str(filePath), isDirectory)
-        directoryList = self.directoryListingLists[requestID]
-        directoryList.append(file)
-
-    def onDirectoryListingComplete(self, deviceID: int, requestID: int):
-        self.directoryListingRequests.pop(requestID, {})
-
-        # If directory was flagged for download
-        if requestID in self.downloadDirectories:
-            self.downloadDirectories.remove(requestID)
-            self.addListingToDownloadQueue(requestID)
-        else:
-            self.crawlListing(requestID)

--- a/pyrdp/mitm/FileMapping.py
+++ b/pyrdp/mitm/FileMapping.py
@@ -70,7 +70,10 @@ class FileMapping:
         # Whether it's a duplicate or a new file, we need to create a link to it in the filesystem clone
         if self.written:
             self.filesystemPath.parents[0].mkdir(exist_ok=True)
-            self.filesystemPath.unlink(missing_ok=True)
+
+            if self.filesystemPath.exists():
+                self.filesystemPath.unlink()
+
             self.filesystemPath.symlink_to(hashPath)
 
             self.log.info("SHA1 '%(path)s' = '%(hash)s'", {

--- a/pyrdp/mitm/FileMapping.py
+++ b/pyrdp/mitm/FileMapping.py
@@ -30,6 +30,10 @@ class FileMapping:
         self.creationTime = creationTime
         self.hash: str = fileHash
 
+    def renameToHash(self):
+        newPath = self.localPath.parents[0] / self.hash
+        self.localPath = self.localPath.rename(newPath)
+
     @staticmethod
     def generate(remotePath: Path, outDir: Path):
         localName = f"{names.get_first_name()}{names.get_last_name()}"

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -85,7 +85,7 @@ class RDPMITM:
         self.statCounter = StatCounter()
         """Class to keep track of connection-related statistics such as # of mouse events, # of output events, etc."""
 
-        self.state = state if state is not None else RDPMITMState(self.config)
+        self.state = state if state is not None else RDPMITMState(self.config, self.log.sessionID)
         """The MITM state"""
 
         self.client = RDPLayerSet()
@@ -152,7 +152,7 @@ class RDPMITM:
             replayFileName = "rdp_replay_{}_{}_{}.pyrdp"\
                     .format(date.strftime('%Y%m%d_%H-%M-%S'),
                             date.microsecond // 1000,
-                            self.log.sessionID)
+                            self.state.sessionID)
             self.recorder.setRecordFilename(replayFileName)
             self.recorder.addTransport(FileLayer(self.config.replayDir / replayFileName))
 
@@ -339,10 +339,10 @@ class RDPMITM:
 
         if self.config.disableActiveClipboardStealing:
             mitm = PassiveClipboardStealer(self.config, clientLayer, serverLayer, self.getLog(MCSChannelName.CLIPBOARD),
-                                           self.recorder, self.statCounter)
+                                           self.recorder, self.statCounter, self.state)
         else:
             mitm = ActiveClipboardStealer(self.config, clientLayer, serverLayer, self.getLog(MCSChannelName.CLIPBOARD),
-                                          self.recorder, self.statCounter)
+                                          self.recorder, self.statCounter, self.state)
         self.channelMITMs[client.channelID] = mitm
 
     def buildDeviceChannel(self, client: MCSServerChannel, server: MCSClientChannel):

--- a/pyrdp/mitm/config.py
+++ b/pyrdp/mitm/config.py
@@ -97,6 +97,13 @@ class MITMConfig:
         return self.outDir / "files"
 
     @property
+    def filesystemDir(self) -> Path:
+        """
+        Get the directory for filesystem clones.
+        """
+        return self.outDir / "filesystems"
+
+    @property
     def certDir(self) -> Path:
         """
         Get the directory for dynamically generated certificates.

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -21,7 +21,7 @@ class RDPMITMState:
     State object for the RDP MITM. This is for data that needs to be shared across components.
     """
 
-    def __init__(self, config: MITMConfig):
+    def __init__(self, config: MITMConfig, sessionID: str):
         self.requestedProtocols: Optional[NegotiationProtocols] = None
         """The original request protocols"""
 
@@ -72,6 +72,9 @@ class RDPMITMState:
 
         self.ctrlPressed = False
         """The current keybaord ctrl state"""
+
+        self.sessionID = sessionID
+        """The current session ID"""
 
         self.securitySettings.addObserver(self.crypters[ParserMode.CLIENT])
         self.securitySettings.addObserver(self.crypters[ParserMode.SERVER])

--- a/test/test_DeviceRedirectionMITM.py
+++ b/test/test_DeviceRedirectionMITM.py
@@ -250,6 +250,13 @@ class DeviceRedirectionMITMTest(unittest.TestCase):
             mapping.localPath.unlink.assert_called_once()
             self.mitm.saveMapping.assert_called_once()
 
+    def test_findNextRequestID_incrementsRequestID(self, *args):
+        baseID = self.mitm.findNextRequestID()
+        self.mitm.sendForgedFileRead(0, Mock())
+        self.assertEqual(self.mitm.findNextRequestID(), baseID + 1)
+        self.mitm.sendForgedFileRead(1, Mock())
+        self.assertEqual(self.mitm.findNextRequestID(), baseID + 2)
+
 
 class ForgedRequestTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_DeviceRedirectionMITM.py
+++ b/test/test_DeviceRedirectionMITM.py
@@ -2,10 +2,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, MagicMock, patch, mock_open
 
-from pyrdp.enum import CreateOption, FileAccessMask, IOOperationSeverity
+from pyrdp.enum import CreateOption, FileAccessMask, IOOperationSeverity, DeviceRedirectionPacketID
 from pyrdp.logging.StatCounter import StatCounter, STAT
 from pyrdp.mitm.DeviceRedirectionMITM import DeviceRedirectionMITM
-from pyrdp.pdu import DeviceIOResponsePDU
+from pyrdp.pdu import DeviceIOResponsePDU, DeviceRedirectionPDU
 
 
 def MockIOError():
@@ -91,6 +91,13 @@ class DeviceRedirectionMITMTest(unittest.TestCase):
         self.mitm.handleClientLogin()
         self.log.info.assert_called_once()
         self.assertTrue(creds in self.log.info.call_args[0][1].values())
+
+        self.mitm.handleClientLogin = Mock()
+        pdu = Mock(packetID = DeviceRedirectionPacketID.PAKID_CORE_USER_LOGGEDON)
+        pdu.__class__ = DeviceRedirectionPDU
+
+        self.mitm.handlePDU(pdu, self.client)
+        self.mitm.handleClientLogin.assert_called_once()
 
     def test_handleIOResponse_uniqueResponse(self, *args):
         handler = Mock()

--- a/test/test_FileMapping.py
+++ b/test/test_FileMapping.py
@@ -1,0 +1,85 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock, mock_open
+
+from pyrdp.mitm.FileMapping import FileMapping
+
+
+class FileMappingTest(unittest.TestCase):
+    def setUp(self):
+        self.log = Mock()
+        self.outDir = Path("test/")
+        self.hash = "testHash"
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("tempfile.mkstemp")
+    @patch("pathlib.Path.mkdir")
+    def createMapping(self, mkdir: MagicMock, mkstemp: MagicMock, mock_open_object):
+        mkstemp.return_value = (1, str(self.outDir / "tmp" / "tmp_test"))
+        mapping = FileMapping.generate("/test", self.outDir, Path("filesystems"), self.log)
+        mapping.getHash = Mock(return_value = self.hash)
+        return mapping, mkdir, mkstemp, mock_open_object
+
+    def test_generate_createsTempFile(self):
+        mapping, mkdir, mkstemp, mock_open_object = self.createMapping()
+        mkstemp.return_value = (1, str(self.outDir / "tmp" / "tmp_test"))
+
+        mkdir.assert_called_once_with(exist_ok = True)
+        mkstemp.assert_called_once()
+        mock_open_object.assert_called_once()
+
+        tmpDir = mkstemp.call_args[0][-1]
+        self.assertEqual(tmpDir, self.outDir / "tmp")
+
+    def test_write_setsWritten(self):
+        mapping, *_ = self.createMapping()
+        self.assertFalse(mapping.written)
+        mapping.write(b"data")
+        self.assertTrue(mapping.written)
+
+    def test_finalize_removesUnwrittenFiles(self):
+        mapping, *_ = self.createMapping()
+
+        with patch("pathlib.Path.unlink", autospec=True) as mock_unlink:
+            mapping.finalize()
+            self.assertTrue(any(args[0][0] == mapping.dataPath for args in mock_unlink.call_args_list))
+
+    @patch("pathlib.Path.exists", new_callable=lambda: Mock(return_value=True))
+    @patch("pathlib.Path.symlink_to")
+    @patch("pathlib.Path.mkdir")
+    def test_finalize_removesDuplicates(self, *_):
+        mapping, *_ = self.createMapping()
+        mapping.write(b"data")
+
+        with patch("pathlib.Path.unlink", autospec=True) as mock_unlink:
+            mapping.finalize()
+            self.assertTrue(any(args[0][0] == mapping.dataPath for args in mock_unlink.call_args_list))
+
+    @patch("pathlib.Path.unlink")
+    @patch("pathlib.Path.exists", new_callable=lambda: Mock(return_value=False))
+    @patch("pathlib.Path.symlink_to")
+    @patch("pathlib.Path.mkdir")
+    def test_finalize_movesFileToOutDir(self, *_):
+        mapping, *_ = self.createMapping()
+        mapping.write(b"data")
+
+        with patch("pathlib.Path.rename") as mock_rename:
+            mapping.finalize()
+            mock_rename.assert_called_once()
+            self.assertEqual(mock_rename.call_args[0][0].parents[0], self.outDir)
+
+    @patch("pathlib.Path.rename")
+    @patch("pathlib.Path.unlink")
+    @patch("pathlib.Path.exists", new_callable=lambda: Mock(return_value=False))
+    def test_finalize_createsSymlink(self, *_):
+        mapping, *_ = self.createMapping()
+        mapping.write(b"data")
+
+        with patch("pathlib.Path.symlink_to") as mock_symlink_to, patch("pathlib.Path.mkdir", autospec=True) as mock_mkdir:
+            mapping.finalize()
+
+            mock_mkdir.assert_called_once()
+            mock_symlink_to.assert_called_once()
+
+            self.assertEqual(mock_mkdir.call_args[0][0], mapping.filesystemPath.parents[0])
+            self.assertEqual(mock_symlink_to.call_args[0][0], self.outDir / self.hash)

--- a/test/test_prerecorded.py
+++ b/test/test_prerecorded.py
@@ -122,7 +122,7 @@ class TestMITM(RDPMITM):
         config.outDir = output_directory
 
         # replay_transport = FileLayer(output_path)
-        state = RDPMITMState(config)
+        state = RDPMITMState(config, log.sessionID)
         super().__init__(log, log, config, state, CustomMITMRecorder([], state))
 
         self.client.tcp.sendBytes = sendBytesStub


### PR DESCRIPTION
Closes issues #261, #264, #268, #270.

Most notably:

- Fix bug preventing files from being closed properly
- Standardize outputs of file crawler and device redirection component so that they both create a "clone" of the victim's filesystem
- Actual files are stored in the `files` folder and are named by hash for easy detection of duplicates
- The `filesystems` folder contains the filesystem clones, and files in this directory are symbolic links to the files in the `files` folder
- Symbolic links are created using the `Path.symlink_to` method in Python and the [documentation](https://docs.python.org/3/library/pathlib.html#pathlib.Path.symlink_to) suggests that this should work on both Linux and Windows
- Unit tests added for `DeviceRedirectionMITM` and `FileMapping`
- No more `mapping.json` file (the information it would contain should be easy to find anyway with the command line, and this simplifies the code)