### PR TITLE
Fix invalid dependency install with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Pip version
         run: pip --version
 
+      - name: Update apt
+        run: sudo apt update -y
       - name: Install setuptools
         run: sudo apt install python3-setuptools
       - name: Install PyRDP dependencies


### PR DESCRIPTION
We were getting the following error with the Linux automated builds:

```
Err:4 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgl1-mesa-glx amd64 20.0.8-0ubuntu1~20.04.1
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-glx_20.0.8-0ubuntu1~20.04.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 276 kB in 0s (2181 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```