### PR TITLE
Create parents when creating symlink's directory

### DIFF
--- a/pyrdp/mitm/FileMapping.py
+++ b/pyrdp/mitm/FileMapping.py
@@ -70,7 +70,7 @@ class FileMapping:
 
         # Whether it's a duplicate or a new file, we need to create a link to it in the filesystem clone
         if self.written:
-            self.filesystemPath.parents[0].mkdir(exist_ok=True)
+            self.filesystemPath.parents[0].mkdir(exist_ok=True, parents=True)
 
             if self.filesystemPath.exists():
                 self.filesystemPath.unlink()

--- a/test/test_FileMapping.py
+++ b/test/test_FileMapping.py
@@ -1,6 +1,6 @@
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock, mock_open
+from unittest.mock import Mock, patch, MagicMock, mock_open, call
 
 from pyrdp.mitm.FileMapping import FileMapping
 
@@ -81,11 +81,7 @@ class FileMappingTest(unittest.TestCase):
             mock_mkdir.assert_called_once()
             mock_symlink_to.assert_called_once()
 
-            self.assertEqual(mock_mkdir.call_args[0][0], mapping.filesystemPath.parents[0])
-            self.assertTrue("exist_ok" in mock_mkdir.call_args.kwargs)
-            self.assertTrue("parents" in mock_mkdir.call_args.kwargs)
-            self.assertTrue(mock_mkdir.call_args.kwargs["exist_ok"])
-            self.assertTrue(mock_mkdir.call_args.kwargs["parents"])
+            self.assertEqual(mock_mkdir.mock_calls[0], call(mapping.filesystemPath.parents[0], exist_ok=True, parents=True))
 
             # The symlink must be a relative symlink.
             # The symlink is in filesystems/ so the link path will start with '..'.

--- a/test/test_FileMapping.py
+++ b/test/test_FileMapping.py
@@ -82,7 +82,6 @@ class FileMappingTest(unittest.TestCase):
             mock_symlink_to.assert_called_once()
 
             self.assertEqual(mock_mkdir.call_args[0][0], mapping.filesystemPath.parents[0])
-            self.assertEqual(len(mock_mkdir.call_args.kwargs), 2)
             self.assertTrue("exist_ok" in mock_mkdir.call_args.kwargs)
             self.assertTrue("parents" in mock_mkdir.call_args.kwargs)
             self.assertTrue(mock_mkdir.call_args.kwargs["exist_ok"])

--- a/test/test_FileMapping.py
+++ b/test/test_FileMapping.py
@@ -82,6 +82,11 @@ class FileMappingTest(unittest.TestCase):
             mock_symlink_to.assert_called_once()
 
             self.assertEqual(mock_mkdir.call_args[0][0], mapping.filesystemPath.parents[0])
+            self.assertEqual(len(mock_mkdir.call_args.kwargs), 2)
+            self.assertTrue("exist_ok" in mock_mkdir.call_args.kwargs)
+            self.assertTrue("parents" in mock_mkdir.call_args.kwargs)
+            self.assertTrue(mock_mkdir.call_args.kwargs["exist_ok"])
+            self.assertTrue(mock_mkdir.call_args.kwargs["parents"])
 
             # The symlink must be a relative symlink.
             # The symlink is in filesystems/ so the link path will start with '..'.


### PR DESCRIPTION
This fixes a bug causing the connection to crash when trying to save a file whose grand-parent directory hasn't been created yet.