### PR TITLE
Fix bugs for TLS PCAPs and refactor pyrdp-convert code

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == master - <unreleased>
 
+=== Breaking Changes
+
+* `pyrdp-convert` command-line interface change: `--list` is now `--list-only` to better reflect what it does.
+  The short form `-l` didn't change. ({uri-issue}311[#311])
+
 === Enhancements
 
 *Security*

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -18,7 +18,8 @@ from pyrdp.player import HAS_GUI
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("input", help="Path to a .pcap or .pyrdp file")
+    parser.add_argument("input", help="Path to a .pcap or .pyrdp file. "
+                                      "Converting from a .pcap will always extract file transfer artifacts in addition to the actual replay.")
     parser.add_argument(
         "-l",
         "--list-only",
@@ -52,8 +53,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-o",
         "--output",
-        help="Path to write the converted files to. If a file name is specified, it will be used as a prefix,"
-        "otherwise the result is output next to the source file with the proper extension.",
+        help="Path to write the converted files to. If a file name is specified, it will be used as a prefix, "
+        "otherwise the result is output next to the source file with the proper extension. "
+        "However if the source of the conversion is a .pcap then this option will create a directory where all files will be stored.",
     )
 
     args = parser.parse_args()

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -69,7 +69,8 @@ if __name__ == "__main__":
 
     if args.output:
         output = Path(args.output)
-        if output.is_dir() or args.format == "replay":
+        # Pcaps create directory structures since they also extract transfered artifacts
+        if output.is_dir() or inputFile.suffix in [".pcap"]:
             outputPrefix = str(output.absolute()) + "/"
         else:
             outputPrefix = str(output.parent.absolute() / output.stem) + "-"

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -104,6 +104,12 @@ class RDPReplayerConfig(MITMConfig):
 
 
 class RDPReplayer(RDPMITM):
+    """
+    This class emulates an RDP MITM instance, but without any actual connections.
+    This is used to build replays from data obtained from a packet capture.
+    It is useful because it reuses the usual components that would be used in a live session.
+    """
+
     def __init__(self, output_path: str, format: str = None):
         def sendBytesStub(_: bytes):
             pass
@@ -129,9 +135,6 @@ class RDPReplayer(RDPMITM):
         self.client.tcp.sendBytes = sendBytesStub
         self.server.tcp.sendBytes = sendBytesStub
         self.state.useTLS = True
-
-    def start(self):
-        pass
 
     def recv(self, data: bytes, from_client: bool):
         try:

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -2,491 +2,18 @@
 
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2020, 2021 GoSecure Inc.
+# Copyright (C) 2020-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
-from progressbar import progressbar
-
-from pyrdp.logging import LOGGER_NAMES, SessionLogger
-from pyrdp.mitm import MITMConfig, RDPMITM
-from pyrdp.mitm.MITMRecorder import MITMRecorder
-from pyrdp.mitm.state import RDPMITMState
-from pyrdp.recording import FileLayer
-from pyrdp.player.BaseEventHandler import BaseEventHandler
-from pyrdp.player.JsonEventHandler import JsonEventHandler
-from pyrdp.player.Replay import Replay
-from pyrdp.layer import PlayerLayer, LayerChainItem
-
-from pyrdp.player import HAS_GUI
-
 import argparse
-from binascii import unhexlify, hexlify
+import logging
+import sys
 from pathlib import Path
 
-# No choice but to import * here for load_layer to work properly.
-from scapy.all import *  # noqa
-
-import logging
-import struct
-import time
-import sys
-
-
-"""
-Supported conversion handlers.
-
-The class constructor signature must be `__init__(self, output_path: str, progress=None)`
-"""
-HANDLERS = {"replay": (None, "pyrdp"), "json": (JsonEventHandler, "json")}
-
-if HAS_GUI:
-    from pyrdp.player.Mp4EventHandler import Mp4EventHandler
-    HANDLERS["mp4"] = (Mp4EventHandler, "mp4")
-else:
-    # Class stub for when MP4 support is not available.
-    # It would be a good idea to refactor this so that Mp4EventHandler is
-    # acquired through some factory object that checks for GUI support
-    # once we add more conversion handlers.
-    class Mp4EventHandler():
-        def __init__(self, _unused: str):
-            pass
-
-
-load_layer("tls")  # noqa
-
-TLS_HDR_LEN = 24  # Hopefully this doesn't change between TLS versions.
-OUTFILE_FORMAT = "{prefix}{timestamp}_{src}-{dst}"
-
-
-def getSink(format: str, outfile: str, progress=None) -> (str, str):
-    """Get the appropriate sink and returns the filename with extension."""
-
-    if format not in HANDLERS:
-        print("[-] Unsupported conversion format.")
-        sys.exit(1)
-
-    sink, ext = HANDLERS[format]
-    outfile += f".{ext}"
-    return sink(outfile, progress=progress) if sink else None, outfile
-
-
-class ConversionLayer(LayerChainItem):
-    """Thin layer that adds a conversion sink to the player."""
-
-    def __init__(self, sink: BaseEventHandler):
-        super().__init__()
-        self.sink = sink
-        self.player = PlayerLayer()
-        self.player.addObserver(sink)
-
-    def sendBytes(self, data: bytes):
-        self.player.recv(data)
-
-
-class CustomMITMRecorder(MITMRecorder):
-    currentTimeStamp: int = None
-
-    def getCurrentTimeStamp(self) -> int:
-        return self.currentTimeStamp
-
-    def setTimeStamp(self, timeStamp: int):
-        self.currentTimeStamp = timeStamp
-
-
-class RDPReplayerConfig(MITMConfig):
-    @property
-    def replayDir(self) -> Path:
-        return self.outDir
-
-    @property
-    def fileDir(self) -> Path:
-        return self.outDir
-
-
-class RDPReplayer(RDPMITM):
-    """
-    This class emulates an RDP MITM instance, but without any actual connections.
-    This is used to build replays from data obtained from a packet capture.
-    It is useful because it reuses the usual components that would be used in a live session.
-    """
-
-    def __init__(self, output_path: str, format: str = None):
-        def sendBytesStub(_: bytes):
-            pass
-
-        output_path = Path(output_path)
-        output_directory = output_path.absolute().parent
-        logger = logging.getLogger(LOGGER_NAMES.MITM_CONNECTIONS)
-        log = SessionLogger(logger, "replay")
-
-        config = RDPReplayerConfig()
-        config.outDir = output_directory
-        # We'll set up the recorder ourselves
-        config.recordReplays = False
-
-        state = RDPMITMState(config, log.sessionID)
-
-        sink, outfile = getSink(format, output_path)
-        transport = ConversionLayer(sink) if sink else FileLayer(outfile)
-        rec = CustomMITMRecorder([transport], state)
-
-        super().__init__(log, log, config, state, rec)
-
-        self.client.tcp.sendBytes = sendBytesStub
-        self.server.tcp.sendBytes = sendBytesStub
-        self.state.useTLS = True
-
-    def recv(self, data: bytes, from_client: bool):
-        try:
-            if from_client:
-                self.client.tcp.dataReceived(data)
-            else:
-                self.server.tcp.dataReceived(data)
-        except Exception as e:
-            print(f"\n[-] Failed to handle data, continuing anyway: {e}")
-
-    def setTimeStamp(self, timeStamp: float):
-        self.recorder.setTimeStamp(int(timeStamp))
-
-    def connectToServer(self):
-        pass
-
-    def startTLS(self, onTlsReady):
-        pass
-
-    def sendPayload(self):
-        pass
-
-
-# noinspection PyUnresolvedReferences
-def tcp_both(p) -> str:
-    """Session extractor which merges both sides of a TCP channel."""
-
-    if "TCP" in p:
-        return str(
-            sorted(["TCP", p[IP].src, p[TCP].sport, p[IP].dst, p[TCP].dport], key=str)
-        )
-    return "Other"
-
-
-# noinspection PyUnresolvedReferences
-def findClientRandom(stream: PacketList, limit: int = 10) -> str:
-    """Find the client random offset and value of a stream."""
-    for n, p in enumerate(stream):
-        if n >= limit:
-            return ""  # Didn't find client hello.
-        try:
-            tls = TLS(p.load)
-            hello = tls.msg[0]
-            if not isinstance(hello, TLSClientHello):
-                continue
-            return hexlify(
-                pkcs_i2osp(hello.gmt_unix_time, 4) + hello.random_bytes
-            ).decode()
-        except Exception:
-            pass  # Not a TLS packet.
-    return ""
-
-
-def loadSecrets(filename: str) -> dict:
-    secrets = {}
-    with open(filename, "r") as f:
-        for line in f:
-            line = line.strip()
-            if line == "" or not line.startswith("CLIENT"):
-                continue
-
-            parts = line.split(" ")
-            if len(parts) != 3:
-                continue
-
-            [t, c, m] = parts
-
-            # Parse the secret accordingly.
-            if t == "CLIENT_RANDOM":
-                secrets[c] = {"client": unhexlify(c), "master": unhexlify(m)}
-    return secrets
-
-
-class Decrypted:
-    """Class for keeping decryption state of a TLS stream."""
-
-    def __init__(self, stream: PacketList, secret: bytes):
-        # Iterator State.
-        self.stream = stream
-        self.ipkt = iter(stream)
-
-        # TLS State.
-        self.secret = secret
-        self.client = None
-        self.server = None
-        self.tls = None
-
-        # Data Flow State.
-        self.src = None
-        self.dst = None
-
-    def __iter__(self):
-        return self
-
-    # noinspection PyUnresolvedReferences
-    def __next__(self):
-        p = next(self.ipkt)
-        ip = p.getlayer(IP)
-        tcp = p.getlayer(TCP)
-
-        if len(tcp.payload) == 0:
-            return p  # Not application data.
-
-        if not self.src:
-            # First packet in the stream, establish sending and receiving ends.
-            self.src = self.last = ip.src
-            self.dst = ip.dst
-            # Create the TLS session context.
-            self.tls = tlsSession(
-                ipsrc=ip.src,
-                ipdst=ip.dst,
-                sport=tcp.sport,
-                dport=tcp.dport,
-                connection_end="server",
-            )
-
-        # Mirror the session if the packet is flowing in the opposite direction.
-        if self.tls.ipsrc != ip.src:
-            self.tls = self.tls.mirror()
-
-        try:
-            frame = TLS(p.load, tls_session=self.tls)
-        except AttributeError as e:
-            if not self.client:
-                return p  # ClientHelo is not sent yet: This is not TLS data.
-            else:
-                raise e  # Should be TLS data.
-
-        # Perform PDU reassembly.
-        if TLSApplicationData in frame:
-            payload = p.load
-            # There could be multiple nested TLS records within the
-            # same TCP packet. In that case we need to consume packets
-            # until The last layer is complete, otherwise it becomes
-            # extremely difficult to decrypt the rest of the stream.
-            tls = frame.lastlayer()
-            while tls.len - tls.deciphered_len - TLS_HDR_LEN > 0:
-                fragment = next(self.ipkt)
-
-                if Raw not in fragment:
-                    continue  # Skip TCP control.
-
-                payload += fragment.load
-                frame = TLS(payload, tls_session=self.tls)
-                tls = frame.lastlayer()
-
-        # FIXME: Maybe rebuild each TLSApplicationData to be a message entry in a single record?
-        tcp.remove_payload()
-        tcp.add_payload(frame)
-        self.tlsSession = frame.tls_session  # Update TLS Context.
-
-        # FIXME: Rather, check if the message is included in it to be sure?
-        msg = frame.msg[0]
-        if isinstance(msg, TLSClientHello):
-            self.client = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
-        elif isinstance(msg, TLSServerHello):
-            self.server = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
-
-        elif isinstance(msg, TLSNewSessionTicket):
-            # Session established, set master secret.
-            self.tls.rcs.derive_keys(
-                client_random=self.client,
-                server_random=self.server,
-                master_secret=self.secret,
-            )
-
-            self.tls.wcs.derive_keys(
-                client_random=self.client,
-                server_random=self.server,
-                master_secret=self.secret,
-            )
-        return p
-
-
-# noinspection PyUnresolvedReferences
-def getStreamInfo(s: PacketList) -> (str, str, float, bool):
-    """Attempt to retrieve an (src, dst, ts, isPlaintext) tuple for a data stream."""
-    packet = s[0]
-
-    if IP in packet:
-        # This is a plaintext stream.
-        #
-        # FIXME: This relies on the fact that decrypted traces are using EXPORTED_PDU and
-        #        thus have no `IP` layer, but it is technically possible to have a true
-        #        plaintext capture with very old implementations of RDP.
-        return (packet[IP].src, packet[IP].dst, packet.time, False)
-    elif Ether not in packet:
-        # No Ethernet layer, so assume exported PDUs.
-        src = ".".join(str(b) for b in packet.load[12:16])
-        dst = ".".join(str(b) for b in packet.load[20:24])
-        return (src, dst, packet.time, True)
-    raise Exception("Invalid stream type. Must be TCP/TLS or EXPORTED PDU.")
-
-
-class Converter:
-    def __init__(self, args):
-        self.args = args
-
-        self.prefix = ""
-
-        self.secrets = loadSecrets(args.secrets) if args.secrets else {}
-
-        if args.output:
-            outdir = Path(args.output)
-            if outdir.is_dir():
-                self.prefix = str(outdir.absolute()) + "/"
-            else:
-                self.prefix = str(outdir.parent.absolute() / outdir.stem) + "-"
-
-    def processPlaintext(self, stream: PacketList, outfile: str, info):
-        """Process a plaintext EXPORTED PDU RDP export to a replay."""
-
-        replayer = RDPReplayer(outfile, format=self.args.format)
-        (client, server, _, _) = info
-        for packet in progressbar(stream):
-            src = ".".join(str(b) for b in packet.load[12:16])
-            dst = ".".join(str(b) for b in packet.load[20:24])
-            data = packet.load[60:]
-
-            if src not in [client, server] or dst not in [client, server]:
-                continue
-
-            replayer.setTimeStamp(int(packet.time * 1000))
-            replayer.recv(data, src == client)
-
-        try:
-            replayer.tcp.recordConnectionClose()
-        except struct.error:
-            print(
-                "Couldn't close the connection cleanly. "
-                "Are you sure you got source and destination correct?"
-            )
-
-    # noinspection PyUnresolvedReferences
-    def processTLS(self, stream: Decrypted, outfile: str):
-        """Process an encrypted TCP stream into a replay file."""
-
-        replayer = RDPReplayer(outfile, format=self.args.format)
-        client = None  # The RDP client's IP.
-
-        for packet in progressbar(stream):
-            ip = packet.getlayer(IP)
-
-            if not client:
-                client = ip.src
-                continue
-
-            if TLSApplicationData not in packet:
-                # This is not TLS application data, skip it, as PyRDP's
-                # network stack cannot parse TLS handshakes.
-                continue
-
-            ts = int(packet.time * 1000)
-            for payload in packet[TLS].iterpayloads():
-                if TLSApplicationData not in payload:
-                    continue  # Not application data.
-                for m in payload.msg:
-                    replayer.setTimeStamp(ts)
-                    replayer.recv(m.data, ip.src == client)
-        try:
-            replayer.tcp.recordConnectionClose()
-        except struct.error:
-            print(
-                "Couldn't close the connection cleanly. "
-                "Are you sure you got source and destination correct?"
-            )
-
-    # noinspection PyUnboundLocalVariable
-    def processPcap(self, infile: Path):
-        print(f"[*] Analyzing PCAP '{infile}' ...")
-        pcap = sniff(offline=str(infile))
-
-        args = self.args
-
-        sessions = pcap.sessions(tcp_both)
-        streams = []
-        n = 0
-
-        for stream in sessions.values():
-            n += 1
-
-            (src, dst, ts, plaintext) = info = getStreamInfo(stream)
-            print(f"    - Session #{n}: {src} -> {dst}:", end="", flush=True)
-
-            if plaintext:
-                print(" plaintext")
-                streams.append((info, stream))
-                continue
-
-            rnd = findClientRandom(stream)
-
-            if rnd == "":
-                print(f" no client random found, skipping session")
-                continue
-
-            if rnd not in self.secrets and rnd != "":
-                print(f" unknown master secret")
-            else:
-                print(f" master secret available (!)")
-                streams.append((info, Decrypted(stream, self.secrets[rnd]["master"])))
-
-        if args.list:
-            return  # List only.
-
-        for (src, dst, ts, plaintext), s in streams:
-            if len(args.src) > 0 and src not in args.src:
-                continue
-            if len(args.dst) > 0 and dst not in args.dst:
-                continue
-
-            print(f"[*] Processing {src} -> {dst}")
-            ts = time.strftime("%Y%M%d%H%m%S", time.gmtime(ts))
-            outfile = OUTFILE_FORMAT.format(
-                **{"prefix": self.prefix, "timestamp": ts, "src": src, "dst": dst}
-            )
-
-            if plaintext:
-                self.processPlaintext(s, outfile, info)
-            else:
-                self.processTLS(s, outfile)
-
-            print(f"\n[+] Successfully wrote '{outfile}'")
-
-    def processReplay(self, infile: Path):
-        with open(infile, "rb") as f:
-            replay = Replay(f)
-
-            print(f"[*] Converting '{infile}' to {self.args.format.upper()}")
-
-            outfile = self.prefix + infile.stem
-            sink, outfile = getSink(self.args.format, outfile)
-
-            if not sink:
-                print("The input file is already a replay file. Nothing to do.")
-                sys.exit(1)
-
-            for event, _ in progressbar(replay):
-                sink.onPDUReceived(event)
-
-            print(f"\n[+] Succesfully wrote '{outfile}'")
-            sink.cleanup()
-
-    def run(self):
-        args = self.args
-        infile = Path(args.input)
-
-        if infile.suffix in [".pcap"]:
-            self.processPcap(infile)
-        elif infile.suffix in [".pyrdp"]:
-            self.processReplay(infile)
-        else:
-            print("Unknown file extension. (Supported: .pcap, .pyrdp)")
+from pyrdp.convert.PCAPConverter import PCAPConverter
+from pyrdp.convert.ReplayConverter import ReplayConverter
+from pyrdp.convert.utils import HANDLERS, loadSecrets
+from pyrdp.player import HAS_GUI
 
 
 if __name__ == "__main__":
@@ -494,7 +21,7 @@ if __name__ == "__main__":
     parser.add_argument("input", help="Path to a .pcap or .pyrdp file")
     parser.add_argument(
         "-l",
-        "--list",
+        "--list-only",
         help="Print the list of sessions in the capture without processing anything",
         action="store_true",
     )
@@ -528,14 +55,38 @@ if __name__ == "__main__":
         help="Path to write the converted files to. If a file name is specified, it will be used as a prefix,"
         "otherwise the result is output next to the source file with the proper extension.",
     )
+
     args = parser.parse_args()
 
-    if not HAS_GUI and args.format == 'mp4':
-        print('Error: MP4 conversion requires the full PyRDP installation.')
+    if not HAS_GUI and args.format == "mp4":
+        sys.stderr.write("Error: MP4 conversion requires the full PyRDP installation.")
         sys.exit(1)
 
     logging.basicConfig(level=logging.CRITICAL)
     logging.getLogger("scapy").setLevel(logging.ERROR)
 
-    c = Converter(args)
-    c.run()
+    inputFile = Path(args.input)
+
+    if args.output:
+        output = Path(args.output)
+        if output.is_dir():
+            outputPrefix = str(output.absolute()) + "/"
+        else:
+            outputPrefix = str(output.parent.absolute() / output.stem) + "-"
+    else:
+        outputPrefix = ""
+
+    if inputFile.suffix in [".pcap"]:
+        secrets = loadSecrets(args.secrets) if args.secrets else None
+        converter = PCAPConverter(inputFile, outputPrefix, args.format, secrets=secrets, srcFilter=args.src, dstFilter=args.dst, listOnly=args.list_only)
+    elif inputFile.suffix in [".pyrdp"]:
+        if args.format == "replay":
+            sys.stderr.write("Refusing to convert a replay file to a replay file. Choose another format.")
+            sys.exit(1)
+
+        converter = ReplayConverter(inputFile, outputPrefix, args.format)
+    else:
+        sys.stderr.write("Unknown file extension. (Supported: .pcap, .pyrdp)")
+        sys.exit(1)
+
+    converter.process()

--- a/bin/pyrdp-convert.py
+++ b/bin/pyrdp-convert.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     if args.output:
         output = Path(args.output)
-        if output.is_dir():
+        if output.is_dir() or args.format == "replay":
             outputPrefix = str(output.absolute()) + "/"
         else:
             outputPrefix = str(output.parent.absolute() / output.stem) + "-"

--- a/pyrdp/convert/Converter.py
+++ b/pyrdp/convert/Converter.py
@@ -1,0 +1,16 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+from pathlib import Path
+
+
+class Converter:
+    def __init__(self, inputFile: Path, outputPrefix: str, format: str):
+        self.inputFile = inputFile
+        self.outputPrefix = outputPrefix
+        self.format = format
+
+    def process(self):
+        raise NotImplementedError("Converter.process is not implemented")

--- a/pyrdp/convert/ExportedPDUStream.py
+++ b/pyrdp/convert/ExportedPDUStream.py
@@ -1,0 +1,45 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+from pyrdp.convert.PCAPStream import PCAPStream
+from pyrdp.convert.pyrdp_scapy import *
+
+
+class ExportedPDUStream(PCAPStream):
+    """
+    PDU stream for converting sessions that contain Wireshark Exported PDU.
+    """
+
+    def __init__(self, client: str, server: str, packets: PacketList):
+        super().__init__(client, server)
+        self.packets = packets
+
+    def __len__(self):
+        return len(self.packets)
+
+    def __iter__(self):
+        return self.parsePDUs()
+
+    def parsePDUs(self):
+        """
+        Generator function that parses Exported PDUs from Wireshark and outputs them.
+        """
+
+        n = 0
+
+        while True:
+            if n >= len(self):
+                raise StopIteration
+
+            packet = self.packets[n]
+            src = ".".join(str(b) for b in packet.load[12:16])
+            dst = ".".join(str(b) for b in packet.load[20:24])
+            data = packet.load[60:]
+            n += 1
+
+            if any(ip not in self.ips for ip in [src, dst]):
+                continue
+
+            yield PCAPStream.output(data, packet.time, src, dst)

--- a/pyrdp/convert/JSONEventHandler.py
+++ b/pyrdp/convert/JSONEventHandler.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2020 GoSecure Inc.
+# Copyright (C) 2020-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -10,14 +10,13 @@ from pyrdp.player.BaseEventHandler import BaseEventHandler
 from pyrdp.parser import ClientInfoParser, ClientConnectionParser, ClipboardParser
 from pyrdp.core import decodeUTF16LE
 
-import logging
 import json
 
 JSON_KEY_INFO = "info"
 JSON_KEY_EVENTS = "events"
 
 
-class JsonEventHandler(BaseEventHandler):
+class JSONEventHandler(BaseEventHandler):
     """
     Playback event handler that converts events to JSON.
 

--- a/pyrdp/convert/MP4EventHandler.py
+++ b/pyrdp/convert/MP4EventHandler.py
@@ -1,0 +1,142 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2020-2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+from pyrdp.enum import BitmapFlags, CapabilityType
+from pyrdp.pdu import BitmapUpdateData, PlayerPDU
+from pyrdp.player.ImageHandler import ImageHandler
+from pyrdp.player.RenderingEventHandler import RenderingEventHandler
+from pyrdp.ui import RDPBitmapToQtImage
+
+import logging
+
+import av
+from PIL import ImageQt
+from PySide2.QtGui import QImage, QPainter, QColor
+
+
+class MP4Image(ImageHandler):
+    """A QRemoteDesktop Mock."""
+    def __init__(self):
+        self.buffer: QImage = None
+
+    def notifyImage(self, x: int, y: int, img: QImage, width: int, height: int):
+        p = QPainter(self.buffer)
+        p.drawImage(x, y, img, 0, 0, width, height)
+
+    def resize(self, width: int, height: int):
+        self.buffer = QImage(width, height, QImage.Format_ARGB32_Premultiplied)
+
+    def update(self):
+        pass
+
+    @property
+    def screen(self) -> QImage:
+        return self.buffer
+
+
+class MP4EventHandler(RenderingEventHandler):
+
+    def __init__(self, filename: str, fps=30, progress=None):
+        """
+        Construct an event handler that outputs to an Mp4 file.
+
+        :param filename: The output file to write to.
+        :param fps: The frame rate (30 recommended).
+        :param progress: An optional callback (sig: `() -> ()`) whenever a frame is muxed.
+        """
+        self.filename = filename
+        self.mp4 = f = av.open(filename, 'w')
+        self.stream = f.add_stream('h264', rate=fps)
+        self.stream.pix_fmt = 'yuv420p'
+        self.progress = progress
+        self.scale = False
+        self.mouse = (0, 0)
+        self.fps = fps
+        self.delta = 1000 // fps  # ms per frame
+        self.log = logging.getLogger(__name__)
+        self.log.info('Begin MP4 export to %s: %d FPS', filename)
+        self.timestamp = self.prevTimestamp = None
+
+        super().__init__(MP4Image())
+
+    def onPDUReceived(self, pdu: PlayerPDU):
+        super().onPDUReceived(pdu)
+
+        # Make sure the rendering surface has been created.
+        if self.imageHandler.screen is None:
+            return
+
+        ts = pdu.timestamp
+        self.timestamp = ts
+
+        if self.prevTimestamp is None:
+            dt = self.delta
+        else:
+            dt = self.timestamp - self.prevTimestamp  # ms
+        nframes = (dt // self.delta)
+        if nframes > 0:
+            for _ in range(nframes):
+                self.writeFrame()
+            self.prevTimestamp = ts
+            self.log.debug('Rendered %d still frame(s)', nframes)
+
+    def cleanup(self):
+        # Add one second worth of padding so that the video doesn't end too abruptly.
+        for _ in range(self.fps):
+            self.writeFrame()
+
+        self.log.info('Flushing to disk: %s', self.filename)
+        for pkt in self.stream.encode():
+            if self.progress:
+                self.progress()
+            self.mp4.mux(pkt)
+        self.log.info('Export completed.')
+        self.mp4.close()
+
+    def onMousePosition(self, x, y):
+        self.mouse = (x, y)
+        super().onMousePosition(x, y)
+
+    def onCapabilities(self, caps):
+        bmp = caps[CapabilityType.CAPSTYPE_BITMAP]
+        (w, h) = (bmp.desktopWidth, bmp.desktopHeight)
+        self.imageHandler.resize(w, h)
+
+        if w % 2 != 0:
+            self.scale = True
+            w += 1
+        if h % 2 != 0:
+            self.scale = True
+            h += 1
+
+        self.stream.width = w
+        self.stream.height = h
+
+        super().onCapabilities(caps)
+
+    def onFinishRender(self):
+        # When the screen is updated, always write a frame.
+        self.prevTimestamp = self.timestamp
+        self.writeFrame()
+
+    def writeFrame(self):
+        w = self.stream.width
+        h = self.stream.height
+        surface = self.imageHandler.screen.scaled(w, h) if self.scale else self.imageHandler.screen.copy()
+
+        # Draw the mouse pointer. Render mouse clicks?
+        p = QPainter(surface)
+        p.setBrush(QColor.fromRgb(255, 255, 0, 180))
+        (x, y) = self.mouse
+        p.drawEllipse(x, y, 5, 5)
+        p.end()
+
+        # Output frame.
+        frame = av.VideoFrame.from_image(ImageQt.fromqimage(surface))
+        for packet in self.stream.encode(frame):
+            if self.progress:
+                self.progress()
+            self.mp4.mux(packet)

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -19,7 +19,7 @@ from pyrdp.convert.utils import tcp_both, getSessionInfo, findClientRandom, crea
 
 
 class PCAPConverter(Converter):
-    OUTFILE_FORMAT = "{timestamp}_{src}-{dst}"
+    SESSIONID_FORMAT = "{timestamp}_{src}-{dst}"
 
     def __init__(self, inputFile: Path, outputPrefix: str, format: str, secrets: Dict = None, srcFilter = None, dstFilter = None, listOnly = False):
         super().__init__(inputFile, outputPrefix, format)
@@ -90,7 +90,7 @@ class PCAPConverter(Converter):
 
     def processStream(self, startTimeStamp: int, stream: PCAPStream):
         startTimeStamp = time.strftime("%Y%M%d%H%m%S", time.gmtime(startTimeStamp))
-        sessionID = PCAPConverter.OUTFILE_FORMAT.format(**{
+        sessionID = PCAPConverter.SESSIONID_FORMAT.format(**{
             "timestamp": startTimeStamp,
             "src": stream.client,
             "dst": stream.server

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -96,8 +96,8 @@ class PCAPConverter(Converter):
             "dst": stream.server
         })
 
-        # Passing None to handler here will use fallback FileLayer handler
-        replayer = RDPReplayer(None, self.outputPrefix, sessionID)
+        handler, _ = createHandler(self.format, self.outputPrefix + sessionID)
+        replayer = RDPReplayer(handler, self.outputPrefix, sessionID)
 
         print(f"[*] Processing {stream.client} -> {stream.server}")
 

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -19,7 +19,7 @@ from pyrdp.convert.utils import tcp_both, getSessionInfo, findClientRandom, crea
 
 
 class PCAPConverter(Converter):
-    OUTFILE_FORMAT = "{prefix}{timestamp}_{src}-{dst}"
+    OUTFILE_FORMAT = "{timestamp}_{src}-{dst}"
 
     def __init__(self, inputFile: Path, outputPrefix: str, format: str, secrets: Dict = None, srcFilter = None, dstFilter = None, listOnly = False):
         super().__init__(inputFile, outputPrefix, format)
@@ -90,15 +90,14 @@ class PCAPConverter(Converter):
 
     def processStream(self, startTimeStamp: int, stream: PCAPStream):
         startTimeStamp = time.strftime("%Y%M%d%H%m%S", time.gmtime(startTimeStamp))
-        outputFileBase = PCAPConverter.OUTFILE_FORMAT.format(**{
-            "prefix": self.outputPrefix,
+        sessionID = PCAPConverter.OUTFILE_FORMAT.format(**{
             "timestamp": startTimeStamp,
             "src": stream.client,
             "dst": stream.server
         })
 
-        handler, outputPath = createHandler(self.format, outputFileBase)
-        replayer = RDPReplayer(handler, outputPath)
+        # Passing None to handler here will use fallback FileLayer handler
+        replayer = RDPReplayer(None, self.outputPrefix, sessionID)
 
         print(f"[*] Processing {stream.client} -> {stream.server}")
 
@@ -111,4 +110,4 @@ class PCAPConverter(Converter):
         except struct.error:
             sys.stderr.write("[!] Couldn't close the session cleanly. Make sure that --src and --dst are correct.")
 
-        print(f"\n[+] Successfully wrote '{outputPath}'")
+        print(f"\n[+] Successfully wrote all files to '{self.outputPrefix}'")

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -1,0 +1,114 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+from pathlib import Path
+
+from progressbar import progressbar
+from scapy.layers.inet import TCP
+from scapy.layers.tls.record import TLS
+
+from pyrdp.convert.Converter import Converter
+from pyrdp.convert.ExportedPDUStream import ExportedPDUStream
+from pyrdp.convert.PCAPStream import PCAPStream
+from pyrdp.convert.RDPReplayer import RDPReplayer
+from pyrdp.convert.TLSPDUStream import TLSPDUStream
+from pyrdp.convert.pyrdp_scapy import *
+from pyrdp.convert.utils import tcp_both, getSessionInfo, findClientRandom, createHandler, canExtractSessionInfo
+
+
+class PCAPConverter(Converter):
+    OUTFILE_FORMAT = "{prefix}{timestamp}_{src}-{dst}"
+
+    def __init__(self, inputFile: Path, outputPrefix: str, format: str, secrets: Dict = None, srcFilter = None, dstFilter = None, listOnly = False):
+        super().__init__(inputFile, outputPrefix, format)
+        self.secrets = secrets if secrets is not None else {}
+        self.srcFilter = srcFilter if srcFilter is not None else srcFilter
+        self.dstFilter = dstFilter if dstFilter is not None else dstFilter
+        self.listOnly = listOnly
+
+    def checkSrcExcluded(self, src: str):
+        return len(self.srcFilter) > 0 and src not in self.srcFilter
+
+    def checkDstExcluded(self, dst: str):
+        return len(self.dstFilter) > 0 and dst not in self.dstFilter
+
+    def process(self):
+        streams = self.listSessions()
+
+        if self.listOnly:
+            return
+
+        for startTimeStamp, stream in streams:
+            try:
+                self.processStream(startTimeStamp, stream)
+            except Exception as e:
+                print(f"\n[-] Failed: {e}")
+
+    def listSessions(self) -> List[Tuple[int, PCAPStream]]:
+        print(f"[*] Analyzing PCAP '{self.inputFile}' ...")
+        bind_layers(TCP, TLS)
+        pcap = sniff(offline=str(self.inputFile), session=TCPSession)
+
+        sessions = pcap.sessions(tcp_both)
+
+        if len(sessions.values()) == 0:
+            print("No sessions found!")
+            return []
+
+        streams: List[Tuple[int, PCAPStream]] = []
+
+        for session in sessions.values():
+            if not canExtractSessionInfo(session):
+                # Skip unsupported sessions (e.g: UDP sessions and such)
+                continue
+
+            client, server, startTimeStamp, plaintext = getSessionInfo(session)
+
+            if self.checkSrcExcluded(client) or self.checkDstExcluded(server):
+                continue
+
+            print(f"    - {client} -> {server}:", end="", flush=True)
+
+            if plaintext:
+                print(" plaintext")
+                stream = ExportedPDUStream(client, server, session)
+            else:
+                clientRandom = findClientRandom(session)
+
+                if clientRandom in self.secrets:
+                    print(" TLS, master secret available (!)")
+                    stream = TLSPDUStream(client, server, session, self.secrets[clientRandom]["master"])
+                else:
+                    print(" TLS, unknown master secret")
+                    continue
+
+            streams.append((startTimeStamp, stream))
+
+        return streams
+
+    def processStream(self, startTimeStamp: int, stream: PCAPStream):
+        startTimeStamp = time.strftime("%Y%M%d%H%m%S", time.gmtime(startTimeStamp))
+        outputFileBase = PCAPConverter.OUTFILE_FORMAT.format(**{
+            "prefix": self.outputPrefix,
+            "timestamp": startTimeStamp,
+            "src": stream.client,
+            "dst": stream.server
+        })
+
+        handler, outputPath = createHandler(self.format, outputFileBase)
+        replayer = RDPReplayer(handler, outputPath)
+
+        print(f"[*] Processing {stream.client} -> {stream.server}")
+
+        for data, timeStamp, src, _ in progressbar(stream):
+            replayer.setTimeStamp(timeStamp)
+            replayer.recv(data, src == stream.client)
+
+        try:
+            replayer.tcp.recordConnectionClose()
+        except struct.error:
+            sys.stderr.write("[!] Couldn't close the session cleanly. Make sure that --src and --dst are correct.")
+
+        print(f"\n[+] Successfully wrote '{outputPath}'")

--- a/pyrdp/convert/PCAPStream.py
+++ b/pyrdp/convert/PCAPStream.py
@@ -1,0 +1,22 @@
+class PCAPStream:
+    def __init__(self, client: str, server: str):
+        self.client = client
+        self.server = server
+
+    @property
+    def ips(self):
+        return [self.client, self.server]
+
+    def __len__(self):
+        raise NotImplementedError("PCAPStream.__len__ is not implemented.")
+
+    def __iter__(self):
+        raise NotImplementedError("PCAPStream.__iter__ is not implemented.")
+
+    @staticmethod
+    def timeStampFloatToInt(timeStamp: float):
+        return int(timeStamp * 1000)
+
+    @staticmethod
+    def output(data: bytes, timeStamp: float, srcIp: str, dstIp: str):
+        return data, PCAPStream.timeStampFloatToInt(timeStamp), srcIp, dstIp

--- a/pyrdp/convert/PCAPStream.py
+++ b/pyrdp/convert/PCAPStream.py
@@ -1,3 +1,8 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
 class PCAPStream:
     def __init__(self, client: str, server: str):
         self.client = client

--- a/pyrdp/convert/RDPReplayer.py
+++ b/pyrdp/convert/RDPReplayer.py
@@ -1,0 +1,101 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+import logging
+from pathlib import Path
+from typing import List
+
+from pyrdp.layer import LayerChainItem, PlayerLayer
+from pyrdp.logging import LOGGER_NAMES, SessionLogger
+from pyrdp.mitm import MITMConfig, RDPMITM
+from pyrdp.mitm.MITMRecorder import MITMRecorder
+from pyrdp.mitm.state import RDPMITMState
+from pyrdp.player import BaseEventHandler
+from pyrdp.recording import FileLayer
+
+
+class RDPReplayerConfig(MITMConfig):
+    @property
+    def replayDir(self) -> Path:
+        return self.outDir
+
+    @property
+    def fileDir(self) -> Path:
+        return self.outDir
+
+
+class OfflineRecorder(MITMRecorder):
+    def __init__(self, transports: List[LayerChainItem], state: RDPMITMState):
+        super().__init__(transports, state)
+        self.currentTimeStamp: int = 0
+
+    def getCurrentTimeStamp(self) -> int:
+        return self.currentTimeStamp
+
+    def setCurrentTimeStamp(self, timeStamp: int):
+        self.currentTimeStamp = timeStamp
+
+
+class ConversionLayer(LayerChainItem):
+    """Thin layer that adds a conversion handler to the player."""
+
+    def __init__(self, handler: BaseEventHandler):
+        super().__init__()
+        self.sink = handler
+        self.player = PlayerLayer()
+        self.player.addObserver(handler)
+
+    def sendBytes(self, data: bytes):
+        self.player.recv(data)
+
+
+class RDPReplayer(RDPMITM):
+    def __init__(self, handler, outputPath: str):
+        def sendBytesStub(_: bytes):
+            pass
+
+        output_directory = Path(outputPath).absolute().parent
+        logger = logging.getLogger(LOGGER_NAMES.MITM_CONNECTIONS)
+        log = SessionLogger(logger, "replay")
+
+        config = RDPReplayerConfig()
+        config.outDir = output_directory
+        # We'll set up the recorder ourselves
+        config.recordReplays = False
+
+        state = RDPMITMState(config, log.sessionID)
+
+        transport = ConversionLayer(handler) if handler else FileLayer(outputPath)
+        rec = OfflineRecorder([transport], state)
+
+        super().__init__(log, log, config, state, rec)
+
+        self.client.tcp.sendBytes = sendBytesStub
+        self.server.tcp.sendBytes = sendBytesStub
+        self.state.useTLS = True
+
+    def start(self):
+        pass
+
+    def recv(self, data: bytes, from_client: bool):
+        try:
+            if from_client:
+                self.client.tcp.dataReceived(data)
+            else:
+                self.server.tcp.dataReceived(data)
+        except Exception as e:
+            print(f"\n[-] Failed to handle data, continuing anyway: {e}")
+
+    def setTimeStamp(self, timeStamp: float):
+        self.recorder.setCurrentTimeStamp(int(timeStamp))
+
+    def connectToServer(self):
+        pass
+
+    def startTLS(self, onTlsReady):
+        pass
+
+    def sendPayload(self):
+        pass

--- a/pyrdp/convert/ReplayConverter.py
+++ b/pyrdp/convert/ReplayConverter.py
@@ -1,0 +1,33 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+import sys
+
+from progressbar import progressbar
+
+from pyrdp.convert.Converter import Converter
+from pyrdp.convert.utils import createHandler
+from pyrdp.player import Replay
+
+
+class ReplayConverter(Converter):
+    def process(self):
+        with open(self.inputFile, "rb") as f:
+            replay = Replay(f)
+
+            print(f"[*] Converting '{self.inputFile}' to {self.format.upper()}")
+
+            outputFileBase = self.outputPrefix + self.inputFile.stem
+            handler, outputPath = createHandler(self.format, outputFileBase)
+
+            if not handler:
+                print("The input file is already a replay file. Nothing to do.")
+                sys.exit(1)
+
+            for event, _ in progressbar(replay):
+                handler.onPDUReceived(event)
+
+            print(f"\n[+] Succesfully wrote '{outputPath}'")
+            handler.cleanup()

--- a/pyrdp/convert/TLSPDUStream.py
+++ b/pyrdp/convert/TLSPDUStream.py
@@ -1,0 +1,108 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+from scapy.layers.inet import TCP, IP
+from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp
+from scapy.layers.tls.handshake import TLSClientHello, TLSServerHello, TLSNewSessionTicket
+from scapy.layers.tls.record import TLSApplicationData, TLS
+from scapy.layers.tls.session import tlsSession
+from scapy.plist import PacketList
+
+from pyrdp.convert.PCAPStream import PCAPStream
+from pyrdp.convert.utils import TCPFlags
+from pyrdp.parser import TPKTParser
+
+
+class TLSPDUStream(PCAPStream):
+    """
+    PDU stream for converting sessions that use TLS.
+    """
+
+    def __init__(self, client: str, server: str, packets: PacketList, masterSecret: str):
+        """
+        The session must have been obtained using by calling bind_layers(TCP, TLS) and then sniff(..., session=TCPSession).
+        This connects the TCP and TLS layers and allows Scapy to reconstruct the TCP stream.
+        """
+
+        super().__init__(client, server)
+        self.packets = packets
+        self.masterSecret = masterSecret
+
+    def __len__(self):
+        return len(self.packets)
+
+    def __iter__(self):
+        return self.decryptTLSStream()
+
+    def decryptTLSStream(self):
+        """
+        Generator function that decrypts an RDP stream that uses TLS.
+        """
+
+        tpktParser = TPKTParser()
+        tls = None
+        clientRandom = None
+        serverRandom = None
+        currentTimeStamp = None
+        reconstructingRecord = False
+        savedRecord = None
+        savedPayload = b""
+        tlsKeyGenerated = False
+
+        for packet in self.packets:
+            ip = packet.getlayer(IP)
+            tcp = packet.getlayer(TCP)
+
+            if len(tcp.payload) == 0 or tcp.flags & TCPFlags.PSH == 0:
+                continue
+
+            currentTimeStamp = packet.time
+            currentSrc = ip.src
+            currentDst = ip.dst
+
+            # The first couple messages don't use TLS. Check if it's one of those messages and output it as is.
+            if hasattr(tcp, "load") and tpktParser.isTPKTPDU(tcp.load):
+                yield PCAPStream.output(tcp.load, currentTimeStamp, ip.src, ip.dst)
+                continue
+
+            # Create the TLS session context.
+            if not tls:
+                tls = tlsSession(
+                    ipsrc=ip.src,
+                    ipdst=ip.dst,
+                    sport=tcp.sport,
+                    dport=tcp.dport,
+                    connection_end="server",
+                )
+
+            if tls.ipsrc != ip.src:
+                tls = tls.mirror()
+
+            # Pass every TLS message through our own custom session so the state is kept properly
+            record = packet[TLS]
+            record = TLS(bytes(record), tls_session=tls)
+
+            for msg in record.msg:
+                if isinstance(msg, TLSClientHello):
+                    clientRandom = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
+                elif isinstance(msg, TLSServerHello):
+                    serverRandom = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
+                elif isinstance(msg, TLSNewSessionTicket):
+                    # Session established, set master secret.
+                    tls.rcs.derive_keys(
+                        client_random=clientRandom,
+                        server_random=serverRandom,
+                        master_secret=self.masterSecret,
+                    )
+
+                    tls.wcs.derive_keys(
+                        client_random=clientRandom,
+                        server_random=serverRandom,
+                        master_secret=self.masterSecret,
+                    )
+
+                    tlsKeyGenerated = True
+                elif isinstance(msg, TLSApplicationData):
+                    yield PCAPStream.output(msg.data, currentTimeStamp, ip.src, ip.dst)

--- a/pyrdp/convert/__init__.py
+++ b/pyrdp/convert/__init__.py
@@ -1,0 +1,5 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#

--- a/pyrdp/convert/pyrdp_scapy.py
+++ b/pyrdp/convert/pyrdp_scapy.py
@@ -1,0 +1,10 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+# No choice but to import * here for load_layer to work properly.
+from scapy.all import *  # noqa
+
+load_layer("tls")  # noqa

--- a/pyrdp/convert/utils.py
+++ b/pyrdp/convert/utils.py
@@ -1,0 +1,129 @@
+#
+# This file is part of the PyRDP project.
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+import enum
+
+from scapy.layers.inet import IP
+from scapy.layers.l2 import Ether
+
+from pyrdp.convert.JSONEventHandler import JSONEventHandler
+from pyrdp.player import HAS_GUI
+
+from pyrdp.convert.pyrdp_scapy import *
+
+"""
+Supported conversion handlers.
+
+The class constructor signature must be `__init__(self, output_path: str, progress=None)`
+"""
+HANDLERS = {"replay": (None, "pyrdp"), "json": (JSONEventHandler, "json")}
+
+if HAS_GUI:
+    from pyrdp.convert.MP4EventHandler import MP4EventHandler
+    HANDLERS["mp4"] = (MP4EventHandler, "mp4")
+else:
+    # Class stub for when MP4 support is not available.
+    # It would be a good idea to refactor this so that Mp4EventHandler is
+    # acquired through some factory object that checks for GUI support
+    # once we add more conversion handlers.
+    class MP4EventHandler():
+        def __init__(self, _unused: str):
+            pass
+
+OUTFILE_FORMAT = "{prefix}{timestamp}_{src}-{dst}"
+
+
+class TCPFlags(enum.IntEnum):
+    FIN = 0x01
+    SYN = 0x02
+    RST = 0x04
+    PSH = 0x08
+    ACK = 0x10
+    URG = 0x20
+    ECE = 0x40
+    CWR = 0x80
+
+
+def createHandler(format: str, outputFileBase: str, progress=None) -> (str, str):
+    """Gets the appropriate handler and returns the filename with extension."""
+
+    if format not in HANDLERS:
+        print("[-] Unsupported conversion format.")
+        sys.exit(1)
+
+    HandlerClass, ext = HANDLERS[format]
+    outputFileBase += f".{ext}"
+    return HandlerClass(outputFileBase, progress=progress) if HandlerClass else None, outputFileBase
+
+
+# noinspection PyUnresolvedReferences
+def tcp_both(p) -> str:
+    """Session extractor which merges both sides of a TCP channel."""
+
+    if "TCP" in p:
+        return str(
+            sorted(["TCP", p[IP].src, p[TCP].sport, p[IP].dst, p[TCP].dport], key=str)
+        )
+    return "Other"
+
+
+# noinspection PyUnresolvedReferences
+def findClientRandom(stream: PacketList, limit: int = 20) -> str:
+    """Find the client random offset and value of a stream."""
+    for n, p in enumerate(stream):
+        if n >= limit:
+            return ""  # Didn't find client hello.
+        try:
+            tls = p[TCP].payload
+            hello = tls.msg[0]
+            if isinstance(hello, TLSClientHello):
+                return (pkcs_i2osp(hello.gmt_unix_time, 4) + hello.random_bytes).hex()
+        except AttributeError as e:
+            continue  # Not a TLS packet.
+
+    return ""
+
+
+def loadSecrets(filename: str) -> dict:
+    secrets = {}
+    with open(filename, "r") as f:
+        for line in f:
+            line = line.strip()
+            if line == "" or not line.startswith("CLIENT"):
+                continue
+
+            parts = line.split(" ")
+            if len(parts) != 3:
+                continue
+
+            [t, c, m] = parts
+
+            # Parse the secret accordingly.
+            if t == "CLIENT_RANDOM":
+                secrets[c] = {"client": bytes.fromhex(c), "master": bytes.fromhex(m)}
+    return secrets
+
+def canExtractSessionInfo(session: PacketList) -> bool:
+    packet = session[0]
+    return IP in packet or Ether not in packet
+
+def getSessionInfo(session: PacketList) -> (str, str, float, bool):
+    """Attempt to retrieve an (src, dst, ts, isPlaintext) tuple for a data stream."""
+    packet = session[0]
+
+    if IP in packet:
+        # This is a plaintext stream.
+        #
+        # FIXME: This relies on the fact that decrypted traces are using EXPORTED_PDU and
+        #        thus have no `IP` layer, but it is technically possible to have a true
+        #        plaintext capture with very old implementations of RDP.
+        return (packet[IP].src, packet[IP].dst, packet.time, False)
+    elif Ether not in packet:
+        # No Ethernet layer, so assume exported PDUs.
+        src = ".".join(str(b) for b in packet.load[12:16])
+        dst = ".".join(str(b) for b in packet.load[20:24])
+        return (src, dst, packet.time, True)
+
+    raise Exception("Invalid stream type. Must be TCP/TLS or EXPORTED PDU.")

--- a/pyrdp/convert/utils.py
+++ b/pyrdp/convert/utils.py
@@ -47,7 +47,11 @@ class TCPFlags(enum.IntEnum):
 
 
 def createHandler(format: str, outputFileBase: str, progress=None) -> (str, str):
-    """Gets the appropriate handler and returns the filename with extension."""
+    """
+    Gets the appropriate handler and returns the filename with extension.
+    Returns None if the format is replay.
+    TODO: Returning None if the format is replay is kind of janky. This could use a refactor to handle replays and other formats differently.
+    """
 
     if format not in HANDLERS:
         print("[-] Unsupported conversion format.")

--- a/pyrdp/convert/utils.py
+++ b/pyrdp/convert/utils.py
@@ -32,8 +32,6 @@ else:
         def __init__(self, _unused: str):
             pass
 
-OUTFILE_FORMAT = "{prefix}{timestamp}_{src}-{dst}"
-
 
 class TCPFlags(enum.IntEnum):
     FIN = 0x01

--- a/pyrdp/layer/player.py
+++ b/pyrdp/layer/player.py
@@ -25,5 +25,9 @@ class PlayerLayer(BufferedLayer):
         pdu = PlayerPDU(messageType, timeStamp, data)
         self.sendPDU(pdu)
 
-    def getCurrentTimeStamp(self) -> int:
+    @staticmethod
+    def timeStampFunction() -> int:
         return int(time.time() * 1000)
+
+    def getCurrentTimeStamp(self) -> int:
+        return PlayerLayer.timeStampFunction()

--- a/pyrdp/layer/player.py
+++ b/pyrdp/layer/player.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018 GoSecure Inc.
+# Copyright (C) 2018, 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/ImageHandler.py
+++ b/pyrdp/player/ImageHandler.py
@@ -1,0 +1,19 @@
+# This file is part of the PyRDP project.
+#
+# Copyright (C) 2021 GoSecure Inc.
+# Licensed under the GPLv3 or later.
+#
+
+class ImageHandler:
+    def notifyImage(self, x: int, y: int, img: 'QImage', width: int, height: int):
+        raise NotImplementedError("ImageHandler.notifyImage is not implemented.")
+
+    def resize(self, width: int, height: int):
+        raise NotImplementedError("ImageHandler.resize is not implemented.")
+
+    def update(self) -> int:
+        raise NotImplementedError("ImageHandler.update is not implemented")
+
+    @property
+    def screen(self) -> 'QImage':
+        raise NotImplementedError("ImageHandler.screen is not implemented")

--- a/pyrdp/player/RenderingEventHandler.py
+++ b/pyrdp/player/RenderingEventHandler.py
@@ -1,6 +1,6 @@
 # This file is part of the PyRDP project.
 #
-# Copyright (C) 2020 GoSecure Inc.
+# Copyright (C) 2020-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/pyrdp/player/gdi/draw.py
+++ b/pyrdp/player/gdi/draw.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2020 GoSecure Inc.
+# Copyright (C) 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -27,6 +27,8 @@ from .raster import set_rop3, set_rop2
 
 from PySide2.QtCore import Qt, QPoint
 from PySide2.QtGui import QImage, QPainter, QColor, QPixmap, QBrush, QPen, QPolygon
+
+from pyrdp.player.ImageHandler import ImageHandler
 
 LOG = logging.getLogger(__name__)
 
@@ -102,8 +104,8 @@ class GdiQtFrontend(GdiFrontend):
     (Make sure that the trace does not contain any sensitive information)
     """
 
-    def __init__(self, dc: QRemoteDesktop):
-        self.dc = dc
+    def __init__(self, imageHandler: ImageHandler):
+        self.imageHandler = imageHandler
         self._warned = False
 
         # Initialize caches.
@@ -114,8 +116,8 @@ class GdiQtFrontend(GdiFrontend):
 
         self.bounds = None
 
-        screen = dc.screen
-        fallback = QImage(dc.width(), dc.height(), QImage.Format_ARGB32_Premultiplied)
+        screen = self.imageHandler.screen
+        fallback = QImage(self.imageHandler.screen.width(), self.imageHandler.screen.height(), QImage.Format_ARGB32_Premultiplied)
         fallback.fill(0)
 
         self.surfaces = {
@@ -463,8 +465,8 @@ class GdiQtFrontend(GdiFrontend):
     def frameMarker(self, state: FrameMarker):
         LOG.debug(state)
         if state.action == 0x01:  # END
-            # self.dc.notifyImage(0, 0, self.screen, self.dc.width(), self.dc.height())
-            self.dc.update()
+            # self.imageHandler.notifyImage(0, 0, self.screen, self.imageHandler.width(), self.imageHandler.height())
+            self.imageHandler.update()
 
     def createOffscreenBitmap(self, state: CreateOffscreenBitmap):
         LOG.debug(state)

--- a/pyrdp/recording/recorder.py
+++ b/pyrdp/recording/recorder.py
@@ -79,7 +79,7 @@ class Recorder:
             layer.sendMessage(data, messageType, timeStamp)
 
     def getCurrentTimeStamp(self) -> int:
-        return PlayerLayer().getCurrentTimeStamp()
+        return PlayerLayer.timeStampFunction()
 
 
 class FileLayer(LayerChainItem):

--- a/pyrdp/recording/recorder.py
+++ b/pyrdp/recording/recorder.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2018-2020 GoSecure Inc.
+# Copyright (C) 2018-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 

--- a/test/test_prerecorded.py
+++ b/test/test_prerecorded.py
@@ -145,7 +145,7 @@ class TestMITM(RDPMITM):
         self.server.tcp.recv(data)
 
     def setTimeStamp(self, timeStamp: float):
-        self.recorder.setCurrentTimeStamp(int(timeStamp * 1000))
+        self.recorder.setTimeStamp(int(timeStamp * 1000))
 
     def connectToServer(self):
         pass

--- a/test/test_prerecorded.py
+++ b/test/test_prerecorded.py
@@ -145,7 +145,7 @@ class TestMITM(RDPMITM):
         self.server.tcp.recv(data)
 
     def setTimeStamp(self, timeStamp: float):
-        self.recorder.setTimeStamp(int(timeStamp * 1000))
+        self.recorder.setCurrentTimeStamp(int(timeStamp * 1000))
 
     def connectToServer(self):
         pass


### PR DESCRIPTION
Big refactor of the pyrdp-convert code and some bug fixes. Most notably:

- The pyrdp-convert code has its own module now (like the player), the launch script only bootstraps this code.
- Classes and functions have been grouped together in separate files instead of having everything in one file.
- We use Scapy's TCP / TLS reconstruction feature instead of doing it manually (which is complicated). Basically, Scapy will first reconstruct all the TLS packets with a generic session (the packets aren't decrypted). Then, we pass all those reconstructed TLS packets in a different session that has the master secret to decrypt them. This works despite the fact that the first couple RDP packets don't actually use TLS.