### PR TITLE
Add clientIp to all JSON logs

### DIFF
--- a/pyrdp/core/ssl.py
+++ b/pyrdp/core/ssl.py
@@ -92,7 +92,7 @@ class CertificateCache():
         base = str(self._root / commonName)
 
         if path.exists(base + '.pem'):
-            self.log.info('Using cached certificate for %s', commonName)
+            self.log.info('Using cached certificate for %(commonName)s', {'commonName': commonName})
 
             # Recover cache entry from disk.
             privKey = base + '.pem'
@@ -110,6 +110,6 @@ class CertificateCache():
             with open(privKey, "wb") as f:
                 f.write(OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, priv))
 
-            self.log.info('Cloned server certificate to %s', certFile)
+            self.log.info('Cloned server certificate to %(certFile)s', {'certFile': certFile})
 
             return privKey, certFile

--- a/pyrdp/core/ssl.py
+++ b/pyrdp/core/ssl.py
@@ -1,12 +1,13 @@
 #
 # Copyright (c) 2014-2020 Sylvain Peyrefitte
-# Copyright (c) 2020 GoSecure Inc.
+# Copyright (c) 2020-2021 GoSecure Inc.
 #
 # This file is part of the PyRDP project.
 #
 # Licensed under the GPLv3 or later.
 #
 
+from typing import Tuple
 from os import path
 
 import OpenSSL
@@ -65,7 +66,7 @@ class CertificateCache():
         self._root = cachedir
         self.log = log
 
-    def clone(self, cert: OpenSSL.crypto.X509) -> (OpenSSL.crypto.PKey, OpenSSL.crypto.X509):
+    def clone(self, cert: OpenSSL.crypto.X509) -> Tuple[OpenSSL.crypto.PKey, OpenSSL.crypto.X509]:
         """Clone the provided certificate."""
 
         # Generate a private key for the server.
@@ -84,7 +85,7 @@ class CertificateCache():
 
         return key, cert
 
-    def lookup(self, cert: OpenSSL.crypto.X509) -> (str, str):
+    def lookup(self, cert: OpenSSL.crypto.X509) -> Tuple[str, str]:
         subject = cert.get_subject()
         parts = dict(subject.get_components())
         commonName = parts[b'CN'].decode()

--- a/pyrdp/logging/adapters.py
+++ b/pyrdp/logging/adapters.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019 GoSecure Inc.
+# Copyright (C) 2019, 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -32,4 +32,10 @@ class SessionLogger(logging.LoggerAdapter):
             sessionID = self.extra["sessionID"]
 
         logger = logging.getLogger(f"{self.name}.{childName}")
-        return SessionLogger(logger, sessionID)
+        sessionLogger = SessionLogger(logger, sessionID)
+
+        # passdown clientIp if present: useful in all JSON log messages
+        if 'clientIp' in self.extra:
+            sessionLogger.extra['clientIp'] = self.extra['clientIp']
+
+        return sessionLogger

--- a/pyrdp/logging/formatters.py
+++ b/pyrdp/logging/formatters.py
@@ -60,6 +60,11 @@ class JSONFormatter(logging.Formatter):
                 "sessionID": record.sessionID
             })
 
+        if hasattr(record, "clientIp"):
+            data.update({
+                "clientIp": record.clientIp
+            })
+
         if isinstance(record.args, dict):
             data.update(record.args)
 

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -190,6 +190,7 @@ class RDPMITM:
         Coroutine that connects to the target RDP server and the attacker.
         Connection to the attacker side has a 1 second timeout to avoid hanging the connection.
         """
+        self.addClientIpToLoggers(self.state.clientIp)
 
         serverFactory = AwaitableClientFactory(self.server.tcp)
         if self.config.transparent:
@@ -453,3 +454,20 @@ class RDPMITM:
         self.config.replayDir.mkdir(exist_ok=True)
         self.config.fileDir.mkdir(exist_ok=True)
         self.config.certDir.mkdir(exist_ok=True)
+
+    def addClientIpToLoggers(self, clientIp: str):
+        """
+        Add the client IP address to all relevant loggers.
+        """
+        self.log.extra['clientIp'] = self.state.clientIp
+        self.clientLog.extra['clientIp'] = self.state.clientIp
+        self.serverLog.extra['clientIp'] = self.state.clientIp
+        self.attackerLog.extra['clientIp'] = self.state.clientIp
+        self.rc4Log.extra['clientIp'] = self.state.clientIp
+
+        self.x224.log.extra['clientIp'] = self.state.clientIp
+        self.mcs.log.extra['clientIp'] = self.state.clientIp
+        self.slowPath.log.extra['clientIp'] = self.state.clientIp
+
+        if self.certs:
+            self.certs.log.extra['clientIp'] = self.state.clientIp

--- a/pyrdp/mitm/TCPMITM.py
+++ b/pyrdp/mitm/TCPMITM.py
@@ -82,6 +82,8 @@ class TCPMITM:
 
         ip = self.client.transport.client[0]
         port = self.client.transport.client[1]
+        self.state.clientIp = ip
+        self.log.extra['clientIp'] = ip
         self.log.info("New client connected from %(clientIp)s:%(clientPort)i",
                       {"clientIp": ip, "clientPort": port})
 
@@ -101,6 +103,7 @@ class TCPMITM:
             self.statCounter.logReport(self.log)
 
         self.server.disconnect(True)
+        self.state.clientIp = None
 
         # For the attacker, we want to make sure we don't abort the connection to make sure that the close event is sent
         self.attacker.disconnect()

--- a/pyrdp/mitm/X224MITM.py
+++ b/pyrdp/mitm/X224MITM.py
@@ -65,6 +65,9 @@ class X224MITM:
         self.originalNegotiationRequest = parser.parse(pdu.payload)
         self.state.requestedProtocols = self.originalNegotiationRequest.requestedProtocols
 
+        # We assign clientIp here since this is fired before RDPMITM has the chance to update all loggers
+        self.log.extra['clientIp'] = self.state.clientIp
+
         if self.originalNegotiationRequest.flags is not None and self.originalNegotiationRequest.flags & NegotiationRequestFlags.RESTRICTED_ADMIN_MODE_REQUIRED:
             self.log.warning("Client has enabled Restricted Admin Mode, which forces Network-Level Authentication (NLA)."
                              " Connection will fail.", {"restrictedAdminActivated": True})

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -76,6 +76,9 @@ class RDPMITMState:
         self.sessionID = sessionID
         """The current session ID"""
 
+        self.clientIp = None
+        """The current client IP address"""
+
         self.windowSize = None
 
         self.effectiveTargetHost = self.config.targetHost

--- a/test/test_X224MITM.py
+++ b/test/test_X224MITM.py
@@ -13,7 +13,7 @@ from pyrdp.pdu import X224ConnectionRequestPDU, NegotiationRequestPDU
 
 class X224MITMTest(unittest.TestCase):
     def setUp(self):
-        self.mitm = X224MITM(Mock(), Mock(), Mock(), Mock(), MagicMock(), MagicMock(), MagicMock())
+        self.mitm = X224MITM(Mock(), Mock(), MagicMock(), Mock(), MagicMock(), MagicMock(), MagicMock())
 
     def test_negotiationFlagsNone_doesntRaise(self):
         connectionRequest = X224ConnectionRequestPDU(0, 0, 0, 0, b"")


### PR DESCRIPTION
PR that resolves #321.

Locally tested, I'll test it further in integration tests that I'll do before the next release.

The only concern I have is whether I should cleanup all loggers or not. For example, should I manually go and destroy all `clientIp` in the `log.extra` dictionary? I'm not doing so right now because the `MITMServerFactory` creates a new object on every connection so loggers should all be reaped.

Bonus: warning removal and logging fixes in `core.ssl`.