### PR TITLE
NLA-redirection fix for #342: rely on host and port

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 * Minor CLI improvements
 
+=== Bug fixes
+
+* Fixed NLA redirection problems if original target and NLA redirection target are the same ({uri-issue}342[#342], {uri-issue}343[#343])
+
 === Infrastructure
 
 * Docker images are now built and pushed via GitHub Actions ({uri-issue}334[#334], {uri-issue}341[#341])

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 === Enhancements
 
 * Minor CLI improvements
+* Improved type hints
 
 === Bug fixes
 

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -4,7 +4,7 @@
 # Licensed under the GPLv3 or later.
 #
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from Crypto.PublicKey import RSA
 
@@ -34,7 +34,7 @@ class RDPMITMState:
         self.securitySettings = SecuritySettings()
         """The security settings for the connection"""
 
-        self.channelDefinitions: [ClientChannelDefinition] = []
+        self.channelDefinitions: List[ClientChannelDefinition] = []
         """The channel definitions from the client"""
 
         self.channelMap: Dict[int, str] = {}

--- a/pyrdp/mitm/state.py
+++ b/pyrdp/mitm/state.py
@@ -118,7 +118,7 @@ class RDPMITMState:
         return None not in [self.config.redirectionHost, self.config.redirectionPort] and not self.isRedirected()
 
     def isRedirected(self) -> bool:
-        return self.effectiveTargetHost == self.config.redirectionHost
+        return self.effectiveTargetHost == self.config.redirectionHost and self.effectiveTargetPort == self.config.redirectionPort
 
     def useRedirectionHost(self):
         self.effectiveTargetHost = self.config.redirectionHost


### PR DESCRIPTION
We relied only on the host to determine if a client was being redirected. Using host/port makes NLA redirection work in useful test situations.