### PR TITLE
Reduce memory usage of pyrdp-convert.py's conversion to video

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 === Enhancements
 
 * `pyrdp-convert` video conversion is now 6x faster! (See {uri-issue}349[#349])
+* `pyrdp-convert` video format can be viewed during encoding and will play even if the conversion process crashes or is halted ({uri-issue}352[#352], {uri-issue}353[#353])
 * Minor CLI improvements
 * Improved type hints
 * Updated instructions to extract the RDP certificate and private key ({uri-issue}345[#345])
@@ -18,6 +19,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 === Bug fixes
 
+* Fixed a memory leak in the bitmap decoding routine preventing the conversion or the replay of very large captures ({uri-issue}352[#352], {uri-issue}353[#353])
 * Fixed NLA redirection problems if original target and NLA redirection target are the same ({uri-issue}342[#342], {uri-issue}343[#343])
 
 === Infrastructure

--- a/pyrdp/convert/MP4EventHandler.py
+++ b/pyrdp/convert/MP4EventHandler.py
@@ -48,7 +48,11 @@ class MP4EventHandler(RenderingEventHandler):
         :param progress: An optional callback (sig: `() -> ()`) whenever a frame is muxed.
         """
         self.filename = filename
-        self.mp4 = f = av.open(filename, 'w')
+        # The movflags puts the encoder in an MP4 Streaming Format. This has two benefits:
+        # - recover partial videos in case of a pyrdp-convert crash
+        # - reduce memory consumption (especially for long captures)
+        # See: https://ffmpeg.org/ffmpeg-formats.html#mov_002c-mp4_002c-ismv
+        self.mp4 = f = av.open(filename, 'w', options={'movflags': 'frag_keyframe+empty_moov'})
         self.stream = f.add_stream('h264', rate=fps)
         # TODO: this undocumented PyAV stream feature needs to be properly investigated
         #       we could probably batch the encoding of several frames and benefit from threads

--- a/pyrdp/player/RenderingEventHandler.py
+++ b/pyrdp/player/RenderingEventHandler.py
@@ -61,7 +61,7 @@ class RenderingEventHandler(BaseEventHandler):
             self.onFinishRender()
 
     def onBitmap(self, bitmapData: BitmapUpdateData):
-        image = RDPBitmapToQtImage(
+        image, _ = RDPBitmapToQtImage(
             bitmapData.width,
             bitmapData.heigth,
             bitmapData.bitsPerPixel,

--- a/pyrdp/player/gdi/cache.py
+++ b/pyrdp/player/gdi/cache.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2020 GoSecure Inc.
+# Copyright (C) 2020-2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 
@@ -8,6 +8,7 @@
 GDI Cache Management Layer.
 """
 
+from typing import List
 from PySide2.QtCore import QSize
 from PySide2.QtGui import QBrush, QImage, QBitmap
 
@@ -15,7 +16,7 @@ from pyrdp.parser.rdp.orders.common import Glyph
 
 
 class BitmapCache:
-    """Bitmap cache."""
+    """Bitmap cache. Structured like this: [cache id][cache index] = (image, buffer)"""
 
     def __init__(self, persist=False):
         self.caches = {}
@@ -53,16 +54,14 @@ class BitmapCache:
             return None
         return cache[idx]
 
-    def add(self, cid: int, idx: int, entry: QImage) -> bool:
+    def add(self, cid: int, idx: int, image: QImage, buffer: bytes) -> bool:
         """
         Add an entry to the cache.
-
-        :returns: True if the entry is a fresh entry, False if it replaced an existing one.
         """
         if cid not in self.caches:
             self.caches[cid] = {}
         cache = self.caches[cid]
-        cache[idx] = entry
+        cache[idx] = (image, buffer)
 
     def evict(self, cid: int, idx: int) -> bool:
         """
@@ -106,13 +105,13 @@ class PaletteCache:
     def has(self, idx: int) -> bool:
         return idx in self.entries
 
-    def get(self, idx: int) -> [int]:
+    def get(self, idx: int) -> List[int]:
         if idx in self.entries:
             return self.entries[idx]
         else:
             return None
 
-    def add(self, idx: int, colors: [int]):
+    def add(self, idx: int, colors: List[int]):
         self.entries[idx] = colors
 
 

--- a/pyrdp/player/gdi/draw.py
+++ b/pyrdp/player/gdi/draw.py
@@ -300,7 +300,7 @@ class GdiQtFrontend(GdiFrontend):
             if src == dst:
                 src = dst.copy()  # Can't paint to same surface.
         else:
-            src = self.bitmaps.get(state.cacheId, state.cacheIndex)
+            src, _ = self.bitmaps.get(state.cacheId, state.cacheIndex)
 
             if src is None:
                 return  # Ignore cache misses.
@@ -314,7 +314,7 @@ class GdiQtFrontend(GdiFrontend):
             # Use offscreen bitmap as a source.
             src = self.surfaces[state.cacheIndex]
         else:
-            src = self.bitmaps.get(state.cacheId, state.cacheIndex)
+            src, _ = self.bitmaps.get(state.cacheId, state.cacheIndex)
 
             if src is None:
                 return  # Ignore cache misses.
@@ -431,18 +431,18 @@ class GdiQtFrontend(GdiFrontend):
     # Secondary Handlers
     def cacheBitmapV1(self, state: CacheBitmapV1):
         LOG.debug(state)
-        bmp = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
-        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp)
+        bmp, buf = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
+        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp, buf)
 
     def cacheBitmapV2(self, state: CacheBitmapV2):
         LOG.debug(state)
-        bmp = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
-        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp)
+        bmp, buf = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
+        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp, buf)
 
     def cacheBitmapV3(self, state: CacheBitmapV3):
         LOG.debug(state)
-        bmp = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
-        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp)
+        bmp, buf = RDPBitmapToQtImage(state.width, state.height,  state.bpp, True, state.data)
+        self.bitmaps.add(state.cacheId, state.cacheIndex, bmp, buf)
 
     def cacheColorTable(self, state: CacheColorTable):
         LOG.debug(state)

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -52,8 +52,7 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
     
     if bitsPerPixel == 15:
         if isCompressed:
-            buf = bytearray(width * height * 2)
-            rle.bitmap_decompress(buf, width, height, data, 2)
+            buf = rle.bitmap_decompress(data, width, height, 2)
             image = QImage(buf, width, height, QImage.Format_RGB555)
         else:
             buf = data
@@ -61,8 +60,7 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
     
     elif bitsPerPixel == 16:
         if isCompressed:
-            buf = bytearray(width * height * 2)
-            rle.bitmap_decompress(buf, width, height, data, 2)
+            buf = rle.bitmap_decompress(data, width, height, 2)
             image = QImage(buf, width, height, QImage.Format_RGB16)
         else:
             buf = data
@@ -70,8 +68,7 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
     
     elif bitsPerPixel == 24:
         if isCompressed:
-            buf = bytearray(width * height * 3)
-            rle.bitmap_decompress(buf, width, height, data, 3)
+            buf = rle.bitmap_decompress(data, width, height, 3)
 
             # This is a ugly patch because there is a bug in the 24bpp decompression in rle.c
             # where the red and the blue colors are inverted. Fixing this in python causes a performance
@@ -89,18 +86,16 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
             
     elif bitsPerPixel == 32:
         if isCompressed:
-            buf = bytearray(width * height * 4)
-            rle.bitmap_decompress(buf, width, height, data, 4)
+            buf = rle.bitmap_decompress(data, width, height, 4)
             image = QImage(buf, width, height, QImage.Format_RGB32)
         else:
             buf = data
             image = QImage(buf, width, height, QImage.Format_RGB32).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
     elif bitsPerPixel == 8:
         if isCompressed:
-            buf = bytearray(width * height * 1)
-            rle.bitmap_decompress(buf, width, height, data, 1)
-            buf2 = convert8bppTo16bpp(buf)
-            image = QImage(buf2, width, height, QImage.Format_RGB16)
+            _buf = rle.bitmap_decompress(data, width, height, 1)
+            buf = convert8bppTo16bpp(_buf)
+            image = QImage(buf, width, height, QImage.Format_RGB16)
         else:
             buf = convert8bppTo16bpp(data)
             image = QImage(buf, width, height, QImage.Format_RGB16).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))

--- a/pyrdp/ui/qt.py
+++ b/pyrdp/ui/qt.py
@@ -48,6 +48,7 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
     :param data: bitmap data
     """
     image = None
+    buf = None
     
     if bitsPerPixel == 15:
         if isCompressed:
@@ -55,7 +56,8 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
             rle.bitmap_decompress(buf, width, height, data, 2)
             image = QImage(buf, width, height, QImage.Format_RGB555)
         else:
-            image = QImage(data, width, height, QImage.Format_RGB555).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+            buf = data
+            image = QImage(buf, width, height, QImage.Format_RGB555).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
     
     elif bitsPerPixel == 16:
         if isCompressed:
@@ -63,7 +65,8 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
             rle.bitmap_decompress(buf, width, height, data, 2)
             image = QImage(buf, width, height, QImage.Format_RGB16)
         else:
-            image = QImage(data, width, height, QImage.Format_RGB16).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+            buf = data
+            image = QImage(buf, width, height, QImage.Format_RGB16).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
     
     elif bitsPerPixel == 24:
         if isCompressed:
@@ -81,7 +84,8 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
 
             image = QImage(buf, width, height, QImage.Format_RGB888)
         else:
-            image = QImage(data, width, height, QImage.Format_RGB888).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+            buf = data
+            image = QImage(buf, width, height, QImage.Format_RGB888).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
             
     elif bitsPerPixel == 32:
         if isCompressed:
@@ -89,7 +93,8 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
             rle.bitmap_decompress(buf, width, height, data, 4)
             image = QImage(buf, width, height, QImage.Format_RGB32)
         else:
-            image = QImage(data, width, height, QImage.Format_RGB32).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+            buf = data
+            image = QImage(buf, width, height, QImage.Format_RGB32).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
     elif bitsPerPixel == 8:
         if isCompressed:
             buf = bytearray(width * height * 1)
@@ -97,12 +102,12 @@ def RDPBitmapToQtImage(width: int, height: int, bitsPerPixel: int, isCompressed:
             buf2 = convert8bppTo16bpp(buf)
             image = QImage(buf2, width, height, QImage.Format_RGB16)
         else:
-            buf2 = convert8bppTo16bpp(data)
-            image = QImage(buf2, width, height, QImage.Format_RGB16).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+            buf = convert8bppTo16bpp(data)
+            image = QImage(buf, width, height, QImage.Format_RGB16).transformed(QMatrix(1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
     else:
         log.error("Receive image in bad format")
         image = QImage(width, height, QImage.Format_RGB32)
-    return image
+    return (image, buf)
 
 
 def convert8bppTo16bpp(buf: bytes):


### PR DESCRIPTION
The first change is to use an MP4 streaming format instead of the default MP4 encoder.

The second makes our BitmapCache track the QImage backing buffer in addition to the QImage itself.

The last one plugs a memory leak in the run length encoding decoding routine in our C extension `rle.c`.

See #352 for the whole story including profiling and performance testing.