### PR TITLE
Security: backported rdesktop fixes in bitmap.c

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == <master> - <unreleased>
 
+=== Security
+
+* Backported security fixes from rdesktop to our Python C extension doing RLE processing.
+  Exploitability wasn't verified. ({uri-issue}357[#357])
+
 === Enhancements
 
 * `pyrdp-convert` video conversion is now 6x faster! (See {uri-issue}349[#349])

--- a/ext/rle.c
+++ b/ext/rle.c
@@ -798,7 +798,7 @@ process_plane(uint8 * in, int width, int height, uint8 * out, int size)
 					replen = revcode;
 					collen = 0;
 				}
-				while (collen > 0)
+				while (indexw < width && collen > 0)
 				{
 					color = CVAL(in);
 					*out = color;
@@ -806,7 +806,7 @@ process_plane(uint8 * in, int width, int height, uint8 * out, int size)
 					indexw++;
 					collen--;
 				}
-				while (replen > 0)
+				while (indexw < width && replen > 0)
 				{
 					*out = color;
 					out += 4;
@@ -828,7 +828,7 @@ process_plane(uint8 * in, int width, int height, uint8 * out, int size)
 					replen = revcode;
 					collen = 0;
 				}
-				while (collen > 0)
+				while (indexw < width && collen > 0)
 				{
 					x = CVAL(in);
 					if (x & 1)
@@ -848,7 +848,7 @@ process_plane(uint8 * in, int width, int height, uint8 * out, int size)
 					indexw++;
 					collen--;
 				}
-				while (replen > 0)
+				while (indexw < width && replen > 0)
 				{
 					x = last_line[indexw * 4] + color;
 					*out = x;


### PR DESCRIPTION
See this commit for details: https://github.com/rdesktop/rdesktop/commit/4dca546d04321a610c1835010b5dad85163b65e1