### PR TITLE
PyRdp-Player optimize for Mac OSX

### DIFF
--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -25,6 +25,7 @@ import logging  # noqa
 import logging.handlers  # noqa
 import sys  # noqa
 import os  # noqa
+# Workaround a macOS bug: https://bugreports.qt.io/browse/QTBUG-87014
 os.environ['QT_MAC_WANTS_LAYER']='1'
 if HAS_GUI:
     from pyrdp.player import MainWindow

--- a/bin/pyrdp-player.py
+++ b/bin/pyrdp-player.py
@@ -25,7 +25,7 @@ import logging  # noqa
 import logging.handlers  # noqa
 import sys  # noqa
 import os  # noqa
-
+os.environ['QT_MAC_WANTS_LAYER']='1'
 if HAS_GUI:
     from pyrdp.player import MainWindow
     from PySide2.QtWidgets import QApplication
@@ -34,7 +34,7 @@ if HAS_GUI:
 def enableNotifications(logger):
     """Enable notifications if supported."""
     # https://docs.python.org/3/library/os.html
-    if os.name != "nt":
+    if os.name != "nt" and sys.platform != "darwin":
         notifyHandler = NotifyHandler()
         notifyHandler.setFormatter(logging.Formatter("[{asctime}] - {message}", style="{"))
 


### PR DESCRIPTION
    Bugfix: 1. fix Memory Not Enough Error (caused by Circular import) by line 37 modification;
    2. fix PySide2 freeze Error by line 28 modification;
    After these modification, pyrdp-player works well on mac osx.