### PR TITLE
fix(359): Support fractional fps.

### DIFF
--- a/pyrdp/convert/MP4EventHandler.py
+++ b/pyrdp/convert/MP4EventHandler.py
@@ -89,13 +89,14 @@ class MP4EventHandler(RenderingEventHandler):
 
         # Prevent drifting when fps doesn't perfectly divide a second.
         nframes = (dt / self.delta) + self.drift
-        self.drift = nframes - floor(nframes)  # update drift.
+        nwhole = floor(nframes)
+        self.drift = nframes - nwhole  # update drift.
 
-        if floor(nframes) > 0:  # Only take whole frames.
-            for _ in range(nframes):
+        if nwhole > 0:  # Only take whole frames.
+            for _ in range(nwhole):
                 self.writeFrame()
             self.prevTimestamp = ts
-            self.log.debug('Rendered %d still frame(s)', nframes)
+            self.log.debug('Rendered %d still frame(s) Drift=%f', nwhole, self.drift)
 
     def cleanup(self):
         # Add one second worth of padding so that the video doesn't end too abruptly.


### PR DESCRIPTION
This pull request fixes #359

I've done two things:

- Default FPS is now 25. (PS: It looks like a recent refactor makes it impossible to configure the FPS for the MP4 converter)
- Use fractional division and keep track of the drift. Whenever we drift by more than one frame, an extra frame is added.

I'm not sure if the drift was a real issue though since we only updated the previous timestamp whenever at least one frame was rendered. In other words, if the timestamp between 2 PDUs is smaller than the frame rate delta, we would just let the delta increase until we've gone past the next integer frame, then render the screen at the current PDU.

The only thing that might happen is that at low frame rates, some information is lost because the screen changes faster than our frame rate can observe. RDP doesn't really have a concept of framerate, updates are sent as they happen, so it's difficult to map it to a constant frame rate.
