### PR TITLE
chore(363): replace notify2 by py-notifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install setuptools
         run: sudo apt install python3-setuptools
       - name: Install PyRDP dependencies
-        run: sudo apt install libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx git python3-dev
+        run: sudo apt install libgl1-mesa-glx git python3-dev
       - name: Install wheel
         working-directory: .
         run: pip install wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 \
         # GUI and notifications stuff
         libgl1-mesa-glx libxcb-xinerama0 \
         notify-osd dbus-x11 libxkbcommon-x11-0 \
+        libnotify-bin \
         # Runtime requirement for PyAV (pyrdp-convert to MP4)
         libavcodec58 libavdevice58 \
         && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-setuptools \
         # Required for venv setup
         python3-venv \
-        # Required to build RLE module (GUI)
+        # Required to build RLE module
         build-essential python3-dev \
         # Required to build PyAV (pyrdp-convert to MP4)
         libavformat-dev libavcodec-dev libavdevice-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-setuptools \
         # Required for venv setup
         python3-venv \
-        # Required to build RLE module and dbus-python (GUI)
+        # Required to build RLE module (GUI)
         build-essential python3-dev \
-        libdbus-1-dev libdbus-glib-1-dev \
         # Required to build PyAV (pyrdp-convert to MP4)
         libavformat-dev libavcodec-dev libavdevice-dev \
         libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
@@ -47,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 \
         python3-distutils \
         # GUI and notifications stuff
         libgl1-mesa-glx libxcb-xinerama0 \
-        notify-osd dbus-x11 libxkbcommon-x11-0 \
+        notify-osd libxkbcommon-x11-0 \
         libnotify-bin \
         # Runtime requirement for PyAV (pyrdp-convert to MP4)
         libavcodec58 libavdevice58 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 \
         python3-distutils \
         # GUI and notifications stuff
         libgl1-mesa-glx libxcb-xinerama0 \
-        notify-osd libxkbcommon-x11-0 \
+        libxkbcommon-x11-0 \
         libnotify-bin \
         # Runtime requirement for PyAV (pyrdp-convert to MP4)
         libavcodec58 libavdevice58 \

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ slim one. Install the dependencies according to your use case.
 sudo apt install python3 python3-pip python3-dev python3-setuptools python3-venv \
         build-essential python3-dev git openssl \
         libgl1-mesa-glx \
-        libnotify-bin notify-osd \
+        libnotify-bin \
         libxkbcommon-x11-0 libxcb-xinerama0 \
         libavformat-dev libavcodec-dev libavdevice-dev \
         libavutil-dev libswscale-dev libswresample-dev libavfilter-dev

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ slim one. Install the dependencies according to your use case.
 sudo apt install python3 python3-pip python3-dev python3-setuptools python3-venv \
         build-essential python3-dev git openssl \
         libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx \
-        notify-osd dbus-x11 libxkbcommon-x11-0 libxcb-xinerama0 \
+        libnotify-bin notify-osd \
+        dbus-x11 libxkbcommon-x11-0 libxcb-xinerama0 \
         libavformat-dev libavcodec-dev libavdevice-dev \
         libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ slim one. Install the dependencies according to your use case.
 # Full install (GUI, transcoding to MP4)
 sudo apt install python3 python3-pip python3-dev python3-setuptools python3-venv \
         build-essential python3-dev git openssl \
-        libdbus-1-dev libdbus-glib-1-dev libgl1-mesa-glx \
+        libgl1-mesa-glx \
         libnotify-bin notify-osd \
-        dbus-x11 libxkbcommon-x11-0 libxcb-xinerama0 \
+        libxkbcommon-x11-0 libxcb-xinerama0 \
         libavformat-dev libavcodec-dev libavdevice-dev \
         libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
 

--- a/pyrdp/logging/handlers.py
+++ b/pyrdp/logging/handlers.py
@@ -8,7 +8,7 @@ import logging
 
 # Dependency not installed on Windows. Notifications are not supported
 try:
-    import notify2
+    from pynotifier import Notification
 except ImportError:
     pass
 
@@ -18,7 +18,6 @@ class NotifyHandler(logging.StreamHandler):
     """
 
     def __init__(self):
-        notify2.init("pyrdp-player")
         super(NotifyHandler, self).__init__()
 
     def emit(self, record):
@@ -26,5 +25,13 @@ class NotifyHandler(logging.StreamHandler):
         Send a notification.
         :param record: the LogRecord object
         """
-        notification = notify2.Notification(record.getMessage())
-        notification.show()
+        try:
+            Notification(
+                title='PyRDP',
+                description=record.getMessage(),
+                # duration=5,  # seconds
+                urgency='normal'
+            ).send()
+        except:
+            # Either libnotify-bin is not installed or the platform does not support notifications.
+            pass

--- a/pyrdp/player/player.default.ini
+++ b/pyrdp/player/player.default.ini
@@ -13,7 +13,7 @@
 # On Windows systems, the file should be in:
 #
 #     %APPDATA%/pyrdp/player.ini
-# 
+#
 # On MacOS:
 #
 #     ~/Library/Application Support/pyrdp/player.ini
@@ -62,7 +62,7 @@ version = 1
 filter = pyrdp
 
 # Enable notifications.
-# This requires a supported operating system with DBus and a
+# This requires a supported operating system with libnotify-bin and a
 # notification daemon.
 notifications = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ hyperlink==21.0.0
 idna==3.2
 incremental==21.3.0
 names==0.3.0
-notify2==0.3.1
 progressbar2==3.53.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
@@ -29,3 +28,4 @@ six==1.16.0
 Twisted==21.7.0
 typing-extensions==3.10.0.0
 zope.interface==5.4.0
+py-notifier==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ av==8.0.3
 cffi==1.14.6
 constantly==15.1.0
 cryptography==3.4.7
-dbus-python==1.2.16
 hyperlink==21.0.0
 idna==3.2
 incremental==21.3.0

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(name='pyrdp',
             'av>=8',
             'PySide2>=5.12,<6',
             'qimage2ndarray>=1.6',
-            'dbus-python>=1.2<1.3;platform_system!="Windows"',
-            'notify2>=0.3,<1;platform_system!="Windows"'
+            'py-notifier>=0.3.0',
+            'win10toast>=0.9;platform_system=="Windows"',
         ]
     }
 )


### PR DESCRIPTION
This replaces notify2 by py-notifier.

I think (but would need further testing) that this allows us to get rid of dbus dependencies since it uses `libnotify-bin`. Which has been added to the README and docker files (not relevant to the CI pipeline AFAIK)

I will investigate whether dbus can be removed and probably open a second PR to cleanup the dependencies.

This also paves the road to eventually supporting windows notifications once win10toast is fixed. (see https://github.com/jithurjacob/Windows-10-Toast-Notifications/issues/86)

Closes #363.