### PR TITLE
fix(331): fix json conversion

### DIFF
--- a/pyrdp/convert/ExportedPDUStream.py
+++ b/pyrdp/convert/ExportedPDUStream.py
@@ -5,6 +5,8 @@
 #
 from pyrdp.convert.PCAPStream import PCAPStream
 from pyrdp.convert.pyrdp_scapy import *
+from pyrdp.convert.utils import InetSocketAddress
+from pyrdp.core import Uint32BE
 
 
 class ExportedPDUStream(PCAPStream):
@@ -12,7 +14,7 @@ class ExportedPDUStream(PCAPStream):
     PDU stream for converting sessions that contain Wireshark Exported PDU.
     """
 
-    def __init__(self, client: str, server: str, packets: PacketList):
+    def __init__(self, client: InetSocketAddress, server: InetSocketAddress, packets: PacketList):
         super().__init__(client, server)
         self.packets = packets
         self.n = 0
@@ -30,12 +32,14 @@ class ExportedPDUStream(PCAPStream):
                 raise StopIteration
 
             packet = self.packets[self.n]
-            src = ".".join(str(b) for b in packet.load[12:16])
-            dst = ".".join(str(b) for b in packet.load[20:24])
+            src = InetSocketAddress(".".join(str(b) for b in packet.load[12:16]),
+                                    Uint32BE.unpack(packet.load[36:40]))
+            dst = InetSocketAddress(".".join(str(b) for b in packet.load[20:24]),
+                                    Uint32BE.unpack(packet.load[44:48]))
             data = packet.load[60:]
             self.n += 1
 
-            if any(ip not in self.ips for ip in [src, dst]):
+            if any(ip not in self.ips for ip in [src.ip, dst.ip]):
                 continue  # Skip packets not meant for this stream.
 
             return PCAPStream.output(data, packet.time, src, dst)

--- a/pyrdp/convert/ExportedPDUStream.py
+++ b/pyrdp/convert/ExportedPDUStream.py
@@ -5,8 +5,7 @@
 #
 from pyrdp.convert.PCAPStream import PCAPStream
 from pyrdp.convert.pyrdp_scapy import *
-from pyrdp.convert.utils import InetSocketAddress
-from pyrdp.core import Uint32BE
+from pyrdp.convert.utils import extractInetAddressesFromPDUPacket, InetAddress
 
 
 class ExportedPDUStream(PCAPStream):
@@ -14,7 +13,7 @@ class ExportedPDUStream(PCAPStream):
     PDU stream for converting sessions that contain Wireshark Exported PDU.
     """
 
-    def __init__(self, client: InetSocketAddress, server: InetSocketAddress, packets: PacketList):
+    def __init__(self, client: InetAddress, server: InetAddress, packets: PacketList):
         super().__init__(client, server)
         self.packets = packets
         self.n = 0
@@ -32,10 +31,7 @@ class ExportedPDUStream(PCAPStream):
                 raise StopIteration
 
             packet = self.packets[self.n]
-            src = InetSocketAddress(".".join(str(b) for b in packet.load[12:16]),
-                                    Uint32BE.unpack(packet.load[36:40]))
-            dst = InetSocketAddress(".".join(str(b) for b in packet.load[20:24]),
-                                    Uint32BE.unpack(packet.load[44:48]))
+            src, dst = extractInetAddressesFromPDUPacket(packet)
             data = packet.load[60:]
             self.n += 1
 

--- a/pyrdp/convert/ExportedPDUStream.py
+++ b/pyrdp/convert/ExportedPDUStream.py
@@ -15,31 +15,27 @@ class ExportedPDUStream(PCAPStream):
     def __init__(self, client: str, server: str, packets: PacketList):
         super().__init__(client, server)
         self.packets = packets
+        self.n = 0
 
     def __len__(self):
         return len(self.packets)
 
     def __iter__(self):
-        return self.parsePDUs()
+        return self
 
-    def parsePDUs(self):
-        """
-        Generator function that parses Exported PDUs from Wireshark and outputs them.
-        """
-
-        n = 0
+    def __next__(self):
 
         while True:
-            if n >= len(self):
+            if self.n >= len(self):
                 raise StopIteration
 
-            packet = self.packets[n]
+            packet = self.packets[self.n]
             src = ".".join(str(b) for b in packet.load[12:16])
             dst = ".".join(str(b) for b in packet.load[20:24])
             data = packet.load[60:]
-            n += 1
+            self.n += 1
 
             if any(ip not in self.ips for ip in [src, dst]):
-                continue
+                continue  # Skip packets not meant for this stream.
 
-            yield PCAPStream.output(data, packet.time, src, dst)
+            return PCAPStream.output(data, packet.time, src, dst)

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -120,4 +120,4 @@ class PCAPConverter(Converter):
         except struct.error:
             sys.stderr.write("[!] Couldn't close the session cleanly. Make sure that --src and --dst are correct.")
 
-        print(f"\n[+] Successfully wrote '{handler.filename}'")
+        print(f"\n[+] Successfully wrote all files to '{self.outputPrefix}'")

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -75,7 +75,7 @@ class PCAPConverter(Converter):
             if self.checkSrcExcluded(client) or self.checkDstExcluded(server):
                 continue
 
-            print(f"    - {client} -> {server}:", end="", flush=True)
+            print(f"    - {client} -> {server} :", end="", flush=True)
 
             if plaintext:
                 print(" plaintext")

--- a/pyrdp/convert/PCAPConverter.py
+++ b/pyrdp/convert/PCAPConverter.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
+import math
 import traceback
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -94,7 +95,7 @@ class PCAPConverter(Converter):
         return streams
 
     def processStream(self, startTimeStamp: int, stream: PCAPStream):
-        startTimeStamp = time.strftime("%Y%m%d%H%M%S", time.gmtime(startTimeStamp))
+        startTimeStamp = time.strftime("%Y%m%d%H%M%S", time.gmtime(math.floor(startTimeStamp)))
         sessionID = PCAPConverter.SESSIONID_FORMAT.format(**{
             "timestamp": startTimeStamp,
             "src": stream.client,

--- a/pyrdp/convert/PCAPStream.py
+++ b/pyrdp/convert/PCAPStream.py
@@ -3,11 +3,11 @@
 # Copyright (C) 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
-from pyrdp.convert.utils import InetSocketAddress
+from pyrdp.convert.utils import InetAddress
 
 
 class PCAPStream:
-    def __init__(self, client: InetSocketAddress, server: InetSocketAddress):
+    def __init__(self, client: InetAddress, server: InetAddress):
         self.client = client
         self.server = server
 
@@ -26,5 +26,5 @@ class PCAPStream:
         return int(timeStamp * 1000)
 
     @staticmethod
-    def output(data: bytes, timeStamp: float, src: InetSocketAddress, dst: InetSocketAddress):
+    def output(data: bytes, timeStamp: float, src: InetAddress, dst: InetAddress):
         return data, PCAPStream.timeStampFloatToInt(timeStamp), src, dst

--- a/pyrdp/convert/PCAPStream.py
+++ b/pyrdp/convert/PCAPStream.py
@@ -3,14 +3,17 @@
 # Copyright (C) 2021 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
+from pyrdp.convert.utils import InetSocketAddress
+
+
 class PCAPStream:
-    def __init__(self, client: str, server: str):
+    def __init__(self, client: InetSocketAddress, server: InetSocketAddress):
         self.client = client
         self.server = server
 
     @property
     def ips(self):
-        return [self.client, self.server]
+        return [self.client.ip, self.server.ip]
 
     def __len__(self):
         raise NotImplementedError("PCAPStream.__len__ is not implemented.")
@@ -23,5 +26,5 @@ class PCAPStream:
         return int(timeStamp * 1000)
 
     @staticmethod
-    def output(data: bytes, timeStamp: float, srcIp: str, dstIp: str):
-        return data, PCAPStream.timeStampFloatToInt(timeStamp), srcIp, dstIp
+    def output(data: bytes, timeStamp: float, src: InetSocketAddress, dst: InetSocketAddress):
+        return data, PCAPStream.timeStampFloatToInt(timeStamp), src, dst

--- a/pyrdp/convert/TLSPDUStream.py
+++ b/pyrdp/convert/TLSPDUStream.py
@@ -11,7 +11,7 @@ from scapy.layers.tls.session import tlsSession
 from scapy.plist import PacketList
 
 from pyrdp.convert.PCAPStream import PCAPStream
-from pyrdp.convert.utils import InetSocketAddress, TCPFlags
+from pyrdp.convert.utils import InetAddress, TCPFlags
 from pyrdp.parser import TPKTParser
 
 
@@ -59,13 +59,13 @@ class TLSPDUStream(PCAPStream):
                 continue
 
             currentTimeStamp = packet.time
-            currentSrcSocket = InetSocketAddress(ip.src, tcp.sport)
+            currentSrcSocket = InetAddress(ip.src, tcp.sport)
 
             # The first couple messages don't use TLS. Check if it's one of those messages and output it as is.
             if hasattr(tcp, "load") and tpktParser.isTPKTPDU(tcp.load):
                 yield PCAPStream.output(tcp.load, currentTimeStamp,
                                         currentSrcSocket,
-                                        InetSocketAddress(ip.dst, tcp.dport))
+                                        InetAddress(ip.dst, tcp.dport))
                 continue
 
             # Create the TLS session context.
@@ -79,7 +79,7 @@ class TLSPDUStream(PCAPStream):
                 )
 
             # Makes sure to reassemble TLS stream properly: client <-> server
-            if currentSrcSocket != InetSocketAddress(tls.ipsrc, tls.sport):
+            if currentSrcSocket != InetAddress(tls.ipsrc, tls.sport):
                 tls = tls.mirror()
 
             # Pass every TLS message through our own custom session so the state is kept properly
@@ -114,4 +114,4 @@ class TLSPDUStream(PCAPStream):
                 elif isinstance(msg, TLSApplicationData):
                     yield PCAPStream.output(msg.data, currentTimeStamp,
                                             currentSrcSocket,
-                                            InetSocketAddress(ip.dst, tcp.dport))
+                                            InetAddress(ip.dst, tcp.dport))

--- a/pyrdp/convert/TLSPDUStream.py
+++ b/pyrdp/convert/TLSPDUStream.py
@@ -11,7 +11,7 @@ from scapy.layers.tls.session import tlsSession
 from scapy.plist import PacketList
 
 from pyrdp.convert.PCAPStream import PCAPStream
-from pyrdp.convert.utils import TCPFlags
+from pyrdp.convert.utils import InetSocketAddress, TCPFlags
 from pyrdp.parser import TPKTParser
 
 
@@ -59,12 +59,13 @@ class TLSPDUStream(PCAPStream):
                 continue
 
             currentTimeStamp = packet.time
-            currentSrc = ip.src
-            currentDst = ip.dst
+            currentSrcSocket = InetSocketAddress(ip.src, tcp.sport)
 
             # The first couple messages don't use TLS. Check if it's one of those messages and output it as is.
             if hasattr(tcp, "load") and tpktParser.isTPKTPDU(tcp.load):
-                yield PCAPStream.output(tcp.load, currentTimeStamp, ip.src, ip.dst)
+                yield PCAPStream.output(tcp.load, currentTimeStamp,
+                                        currentSrcSocket,
+                                        InetSocketAddress(ip.dst, tcp.dport))
                 continue
 
             # Create the TLS session context.
@@ -77,7 +78,8 @@ class TLSPDUStream(PCAPStream):
                     connection_end="server",
                 )
 
-            if tls.ipsrc != ip.src:
+            # Makes sure to reassemble TLS stream properly: client <-> server
+            if currentSrcSocket != InetSocketAddress(tls.ipsrc, tls.sport):
                 tls = tls.mirror()
 
             # Pass every TLS message through our own custom session so the state is kept properly
@@ -88,6 +90,11 @@ class TLSPDUStream(PCAPStream):
                 if isinstance(msg, TLSClientHello):
                     clientRandom = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
                 elif isinstance(msg, TLSServerHello):
+                    # TODO: faced some cases where random_bytes was the right length already
+                    #       but also it didn't entirely fix that case...
+                    #if len(msg.random_bytes) == 32:
+                    #    serverRandom = msg.random_bytes
+                    #else:
                     serverRandom = pkcs_i2osp(msg.gmt_unix_time, 4) + msg.random_bytes
                 elif isinstance(msg, TLSNewSessionTicket):
                     # Session established, set master secret.
@@ -105,4 +112,6 @@ class TLSPDUStream(PCAPStream):
 
                     tlsKeyGenerated = True
                 elif isinstance(msg, TLSApplicationData):
-                    yield PCAPStream.output(msg.data, currentTimeStamp, ip.src, ip.dst)
+                    yield PCAPStream.output(msg.data, currentTimeStamp,
+                                            currentSrcSocket,
+                                            InetSocketAddress(ip.dst, tcp.dport))


### PR DESCRIPTION
This PR addresses several issues with the pyrdp-convert refactor:

- Missing scapy imports leading to exceptions when converting
- Bad `__iter__` implementation for `ExportedPDUStream` resulting in improper cleanup
- Missing handler cleanup call in `PCAPConverter`

Among other things, it closes #331.

Tested on both encrypted pcaps and ExportedPDU pcaps.