### PR TITLE
Dropping support of pre-built docker images for linux/arm/v7

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.slim
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -28,11 +28,6 @@ RUN pip3 --no-cache-dir install -U pip wheel
 
 # Install dependencies only (speeds repetitive builds)
 COPY requirements-slim.txt /pyrdp/requirements.txt
-# The following allows us to install the cryptography package.
-# Eventually we will add rust to our compile-image and build with rust but
-# rust's cargo is broken on docker ARM right now and we will wait until
-# upstream is fixed.
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 RUN cd /pyrdp && pip3 --no-cache-dir install -r requirements.txt
 
 # Compile only our C extension and install

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Afterwards, you can execute PyRDP by invoking the `pyrdp` docker container. See 
 Cross-platform builds can be achieved using `buildx`:
 
 ```
+docker buildx create --name mybuilder --use --platform linux/amd64,linux/arm64
+docker buildx inspect --bootstrap
 docker buildx build --platform linux/arm,linux/amd64 -t pyrdp -f Dockerfile.slim .
 ```
 


### PR DESCRIPTION
Cryptography requires rustc and cargo in order to build since [the beginning of last year](https://github.com/pyca/cryptography/issues/5771). We carried a workaround when we implemented ARM builds for docker in 724bd5ef1a94.

When I pushed the dependency updates, our ARMv7 (aka armhf) docker builds stopped working: https://github.com/GoSecure/pyrdp/runs/4861875591?check_suite_focus=true.

After investigation, the cryptography project seemed to have stepped up and is providing prebuilt cryptography packages for a lot of platforms but not linux/arm/v7 and they have no intention of doing so: https://github.com/pyca/cryptography/issues/6286.

I spent one hour trying to build the package inside the compile container with rust and cargo installed but it would fail for various reasons including obscure linux or QEMU ones. Thinking about how many linux/arm/v7 users we might have out there I don't think it's worth the effort.

If someone reads this, know that you can always install pyrdp from source and it should work since the issues were around cargo having problems with the docker+QEMU emulation.

We still build docker images for ARM64 (aka aarch64).