### PR TITLE
Closing recording file descriptors on more occasions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,7 +45,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Fixed `pyrdp-player` on macOS platforms ({uri-issue}362[#362])
 * Fixed `pyrdp-convert` pcap processing when victim IP and MITM IP are the same ({uri-issue}366[#366])
 * Fixed NLA redirection problems if original target and NLA redirection target are the same ({uri-issue}342[#342], {uri-issue}343[#343])
-* Fixed leak of file descriptors due to missing close on replay file recording ({uri-issue}392[#392], {uri-issue}413[#413])
+* Fixed leak of file descriptors due to missing close on replay file recording ({uri-issue}392[#392], {uri-issue}413[#413], {uri-issue}415[#415])
 * Added a missing dependency for the GUI on Ubuntu 20.04 LTS ({uri-issue}348[#348], {uri-issue}351[#351], {uri-issue}355[#355])
 * No longer assuming every connection will have VirtualChannels ({uri-issue}375[#375])
 * Some minor protocol-level fixes ({uri-issue}408[#408])

--- a/pyrdp/mitm/TCPMITM.py
+++ b/pyrdp/mitm/TCPMITM.py
@@ -99,10 +99,10 @@ class TCPMITM:
         if self.recorder.recordFilename:
             self.statCounter.logReport(self.log, {"replayFilename":
                                                   self.recorder.recordFilename})
-            self.recorder.finalize()
         else:
             self.statCounter.logReport(self.log)
 
+        self.recorder.finalize()
         self.server.disconnect(True)
         self.state.clientIp = None
 
@@ -123,6 +123,7 @@ class TCPMITM:
         """
 
         self.recordConnectionClose()
+        self.recorder.finalize()
         self.log.info("Server connection closed. %(reason)s", {"reason": reason.value})
         self.client.disconnect(True)
 


### PR DESCRIPTION
Fixes dangling file descriptors when the connection is terminated by the server