### PR TITLE
Fix a hard to find problem in DeviceRedirection

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,6 +41,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 === Bug fixes
 
+* Fixed situations where device redirection or clipboard sharing would hang and timeout ({uri-issue}139[#139], {uri-issue}422[#422])
 * Fixed a memory leak in the bitmap decoding routine preventing the conversion or the replay of very large captures ({uri-issue}352[#352], {uri-issue}353[#353])
 * Fixed `pyrdp-player` on macOS platforms ({uri-issue}362[#362])
 * Fixed `pyrdp-convert` pcap processing when victim IP and MITM IP are the same ({uri-issue}366[#366])

--- a/pyrdp/mitm/RDPMITM.py
+++ b/pyrdp/mitm/RDPMITM.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the PyRDP project.
-# Copyright (C) 2019-2021 GoSecure Inc.
+# Copyright (C) 2019-2022 GoSecure Inc.
 # Licensed under the GPLv3 or later.
 #
 


### PR DESCRIPTION
Specific file transfers would hang. A minimal reproducer was hard to create. It turns out that the issue was in the encapsulation of the TLSSecurityLayer. If a virtual channel packet has a specific length (0x80), it would confuse the next layer into thinking it was the Security Header's licensing bytes causing the payload to be skipped from its usual processing.

See the `recv()` method of the `TLSSecurityLayer` class in `pyrdp/layer/rdp/security.py`.

Turns out that the security layer is not required if we are using modern RDP access mechanisms (anything more recent than RC4) so we can just remove the layer when the MITM is set up.

This fix happens to fix #139 as well.

Big shoutout to @xshill to help me dig for the root cause and fix the issue. Honorable mention to Flare Systems for letting me borrow him for one day last week.