### PR TITLE
Update rdp.py

### DIFF
--- a/pyrdp/enum/rdp.py
+++ b/pyrdp/enum/rdp.py
@@ -254,6 +254,7 @@ class RDPVersion(IntEnum):
     RDP10_8 = 0x8000d
     RDP10_9 = 0x8000e
     RDP10_10 = 0x8000f
+    RDP10_11 = 0x80010
 
 
 class ColorDepth(IntEnum):


### PR DESCRIPTION
adding RDP10_11 due to error builtins.ValueError: 524304 is not a valid RDPVersion when connecting via win11 RDP