### PR TITLE
Fixed bug with PDU handling in headless mode

### DIFF
--- a/pyrdp/player/Replay.py
+++ b/pyrdp/player/Replay.py
@@ -19,6 +19,7 @@ class Replay:
     """
 
     def __init__(self, file: BinaryIO):
+        currentMsgIndex = 0
         self.events: Dict[int, List[int]] = {}
         self.file = file
 
@@ -36,7 +37,9 @@ class Replay:
             # Register PDUs as they are parsed by the layer
             def registerEvent(pdu: PlayerPDU):
                 nonlocal currentMessagePosition
-                events[pdu.timestamp].append(currentMessagePosition)
+                nonlocal currentMsgIndex
+                events[currentMsgIndex].append(currentMessagePosition)
+                currentMsgIndex = currentMsgIndex + 1
 
             # Register the offset of every event in the file.
             player = PlayerLayer()


### PR DESCRIPTION
This fixes a bug with headless replay of files, specifically those created by pyrdp-convert.py which seems to set the timestamp to 0. Using the timestamp is probably bad anyway due to the risk of collision.