### PR TITLE
Add listenAddress, listenPort and hostIp to JSON logs on MITM start

### DIFF
--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -27,7 +27,7 @@ from pyrdp.logging import LOGGER_NAMES
 
 def main():
     config = configure()
-    logger = logging.getLogger(LOGGER_NAMES.PYRDP)
+    logger = logging.getLogger(LOGGER_NAMES.MITM_CONNECTIONS)
 
     # Create a listening socket to accept connections.
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/bin/pyrdp-mitm.py
+++ b/bin/pyrdp-mitm.py
@@ -50,8 +50,8 @@ def main():
     params = {"address": config.listenAddress, "port": config.listenPort}
 
     if "HOST_IP" in os.environ:
-        message += ". Host IP: %(host_ip)s"
-        params["host_ip"] = os.environ["HOST_IP"]
+        message += ". Host IP: %(hostIp)s"
+        params["hostIp"] = os.environ["HOST_IP"]
 
     logger.info(message, params)
 


### PR DESCRIPTION
and also log in JSON when the MITM stops

This was what was originally intended when adding HOST_IP but it turned out it was only console and file logged, never reached the JSON log.