### PR TITLE
Add missing libqxcb dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 \
         python3-distutils \
         # GUI and notifications stuff
         libgl1-mesa-glx libxcb-xinerama0 \
+        libxcb-icccm4 libxcb-image0 libxcb-util1 libxcb-keysyms1 \
+        libxcb-randr0 libxcb-render-util0 \
         libxkbcommon-x11-0 \
         libnotify-bin \
         # Runtime requirement for PyAV (pyrdp-convert to MP4)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ sudo apt install python3 python3-pip python3-dev python3-setuptools python3-venv
         libgl1-mesa-glx \
         libnotify-bin \
         libxkbcommon-x11-0 libxcb-xinerama0 \
+        libxcb-icccm4 libxcb-image0 libxcb-util1 libxcb-keysyms1 \
+        libxcb-randr0 libxcb-render-util0 \
         libavformat-dev libavcodec-dev libavdevice-dev \
         libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
 


### PR DESCRIPTION
I run into an issue similar to https://github.com/GoSecure/pyrdp/issues/351 running pyrdp-convert.py (or pyrdp-player.py) in docker (both the latest image from dockerhub, as well as an image built locally from the Dockerfile):
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.

Aborted (core dumped)
```
Running with `QT_DEBUG_PLUGINS` I found out that libqxcb failed to load:
```
Cannot load library /opt/venv/lib/python3.8/site-packages/PySide2/Qt/plugins/platforms/libqxcb.so: (libxcb-icccm.so.4: cannot open shared object file: No such file or directory)
``` 
Digging further with `ldd` I identified a couple of missing libraries:
```
ldd /opt/venv/lib/python3.8/site-packages/PySide2/Qt/plugins/platforms/libqxcb.so | grep 'not found'
        libxcb-icccm.so.4 => not found
        libxcb-image.so.0 => not found
        libxcb-util.so.1 => not found
        libxcb-keysyms.so.1 => not found
        libxcb-randr.so.0 => not found
        libxcb-render-util.so.0 => not found
```

Installing these libraries with apt-get in the Dockerfile fixed the issue and I was able to produce an mp4 output. Perhaps something has changed in Ubuntu repositories.