### PR TITLE
Clipboard files deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,16 @@ pyrdp_output/
 │   └── WinDev2108Eval.pem
 ├── files
 │   ├── e91c6a5eb3ca15df5a5cb4cf4ebb6f33b2d379a3a12d7d6de8c412d4323feb4c
+│   ├── b14b26b7d02c85e74ab4f0d847553b2fdfaf8bc616f7c3efcc4771aeddd55700
 ├── filesystems
-│   ├── Kimberly835337
+│   ├── romantic_kalam_8214773
 │   │   └── device1
-│   └── Stephen215343
+│   │   └── clipboard
+|           └── priv-esc.exe -> ../../../files/b14b26b7d02c85e74ab4f0d847553b2fdfaf8bc616f7c3efcc4771aeddd55700
+│   └── happy_stonebraker_1992243
 │       ├── device1
 │       └── device2
-|           └── Users/User/3D Objects/desktop.ini
+|           └── Users/User/3D Objects/desktop.ini -> ../../../../../../e91c6a5eb3ca15df5a5cb4cf4ebb6f33b2d379a3a12d7d6de8c412d4323feb4c
 ├── logs
 │   ├── crawl.json
 │   ├── crawl.log
@@ -195,8 +198,8 @@ pyrdp_output/
 │   ├── player.log
 │   └── ssl.log
 └── replays
-    ├── rdp_replay_20210826_12-15-33_512_Stephen215343.pyrdp
-    └── rdp_replay_20211125_12-55-42_352_Kimberly835337.pyrdp
+    ├── rdp_replay_20231214_01-20-28_965_happy_stonebraker_1992243.pyrdp
+    └── rdp_replay_20231214_00-42-24_295_romantic_kalam_8214773.pyrdp
 ```
 
 * `certs/` contains the certificates generated stored using the `CN` of the certificate as the file name

--- a/pyrdp/mitm/ClipboardMITM.py
+++ b/pyrdp/mitm/ClipboardMITM.py
@@ -256,7 +256,7 @@ class FileTransferMappingProxy():
     def onRequest(self, pdu: FileContentsRequestPDU):
         # TODO: Handle out of order ranges. Are they even possible?
         self.prev = pdu
-    
+
     def onResponse(self, pdu: FileContentsResponsePDU) -> bool:
         """
         Handle file data.

--- a/test/test_FileMapping.py
+++ b/test/test_FileMapping.py
@@ -22,7 +22,7 @@ class FileMappingTest(unittest.TestCase):
     def createMapping(self, mkdir: MagicMock, mkstemp: MagicMock, mock_open_object):
         mkstemp.return_value = (1, str(self.outDir / "tmp" / "tmp_test"))
         mapping = FileMapping.generate("/test", self.outDir, Path("filesystems"), self.log)
-        mapping.getShaHash = Mock(return_value = self.hash)
+        mapping._getShaHash = Mock(return_value = self.hash)
         mapping.file.closed = False
         return mapping, mkdir, mkstemp, mock_open_object
 


### PR DESCRIPTION
TODO:
* [x] use special `clipboard/` storage under filesystems instead
* [x] re-test mapped drives and clipboard transfers (w/ and w/o folders)