### PR TITLE
Set a default value for clipboard clipDataId

### DIFF
--- a/pyrdp/parser/rdp/virtual_channel/clipboard.py
+++ b/pyrdp/parser/rdp/virtual_channel/clipboard.py
@@ -51,7 +51,12 @@ class ClipboardParser(Parser):
         posLo = Uint32LE.unpack(stream)
         posHi = Uint32LE.unpack(stream)
         cbRequested = Uint32LE.unpack(stream)
-        clipDataId = Uint32LE.unpack(stream)
+        # xfreeRDP (and maybe other non-Windows clients?) don't send a clipDataId.
+        # Currently we don't use clipDataId for anything, so we can safely just set it to 0.
+        try:
+            clipDataId = Uint32LE.unpack(stream)
+        except ValueError:
+            clipDataId = 0
 
         pos = posHi << 32 | posLo
         return FileContentsRequestPDU(payload, streamId, lindex, msgFlags, dwFlags, pos, cbRequested, clipDataId)


### PR DESCRIPTION
xfreeRDP (and maybe other non-Windows clients?) don't send a `clipDataId`, which makes the code crash when trying to extract a file being copied over RDP.

Currently we don't use `clipDataId` for anything, so we can safely just set it to 0.